### PR TITLE
Roll refactor

### DIFF
--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -19,7 +19,7 @@ public enum DieError: ErrorType {
 /**
 An imaginary die with `0` to `Int.max` sides.
 */
-public struct Die {
+public struct Die: Equatable {
     
     /**
     A type that "rolls" an imaginary die with `sides` number of sides and returns the result.
@@ -54,4 +54,9 @@ public struct Die {
         return Die.roller(sides: sides)
     }
     
+}
+
+// MARK: - Equatable
+public func ==(lhs: Die, rhs: Die) -> Bool {
+    return lhs.sides == rhs.sides
 }

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -22,6 +22,20 @@ An imaginary die with `0` to `Int.max` sides.
 public struct Die: Equatable {
     
     /**
+    The result of rolling a `Die`.
+    */
+    public struct Roll: Equatable {
+        
+        public let die: Die
+        public let value: Int
+        
+        public init(die: Die, value: Int) {
+            self.die = die
+            self.value = value
+        }
+    }
+    
+    /**
     A type that "rolls" an imaginary die with `sides` number of sides and returns the result.
     
     Passing a value less than `0` for `sides` is undefined.
@@ -45,13 +59,14 @@ public struct Die: Equatable {
     }
     
     /**
-    Rolls the die and returns the result.
+    Rolls the die and returns the result as a `Die.Roll`.
     
-    - returns: A value determined by `Die.roller` by passing in
-        `self.sides` for `sides`.
+    - returns: A `Die.Roll` initiated with `self` and the value determined by
+        `Die.roller` by passing in `self.sides` for `sides`.
     */
-    public func roll() -> Int {
-        return Die.roller(sides: sides)
+    public func roll() -> Roll {
+        let result = Die.roller(sides: sides)
+        return Roll(die: self, value: result)
     }
     
 }
@@ -59,4 +74,8 @@ public struct Die: Equatable {
 // MARK: - Equatable
 public func ==(lhs: Die, rhs: Die) -> Bool {
     return lhs.sides == rhs.sides
+}
+
+public func ==(lhs: Die.Roll, rhs: Die.Roll) -> Bool {
+    return lhs.die == rhs.die && lhs.value == rhs.value
 }

--- a/DiceKitTests/DieTests.swift
+++ b/DiceKitTests/DieTests.swift
@@ -98,6 +98,63 @@ extension Die_Test {
     
 }
 
+// MARK: - Equatatable
+extension Die_Test {
+    
+    func test_shouldBeReflexive() {
+        property["reflexive"] = forAll {
+            (i: PositiveSidesType) in
+            
+            let sides = Int(i)
+            
+            let x = try! Die(sides: sides)
+            
+            return x == x
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property["symmetric"] = forAll {
+            (i: PositiveSidesType) in
+            
+            let sides = Int(i)
+            
+            let x = try! Die(sides: sides)
+            let y = try! Die(sides: sides)
+            
+            return x == y && y == x
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property["transitive"] = forAll {
+            (i: PositiveSidesType) in
+            
+            let sides = Int(i)
+            
+            let x = try! Die(sides: sides)
+            let y = try! Die(sides: sides)
+            let z = try! Die(sides: sides)
+            
+            return x == y && y == z && x == z
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property["non-equal"] = forAll {
+            (a: PositiveSidesType, b: PositiveSidesType) in
+            
+            guard a != b else { return true }
+            
+            let x = try! Die(sides: Int(a))
+            let y = try! Die(sides: Int(b))
+            
+            return x != y
+        }
+    }
+    
+}
+
 // MARK: - roll() tests
 extension Die_Test {
     

--- a/DiceKitTests/DieTests.swift
+++ b/DiceKitTests/DieTests.swift
@@ -14,6 +14,13 @@ import DiceKit
 
 /// Tests the `Die` type
 class Die_Test: XCTestCase {
+    
+    #if arch(i386) || arch(arm) // 32-bit
+        typealias PositiveSidesType = UInt16
+    #else // 64-bit
+        typealias PositiveSidesType = UInt32
+    #endif
+    
 }
 
 // MARK: - init() tests
@@ -154,9 +161,11 @@ extension Die_Test {
     
     func test_RollerType_shouldReturnWithinRangeForSidesGreaterThan1() {
         property["RollerType generates values within range of 1...sides"] = forAll {
-            (sides: Int) in
+            (i: PositiveSidesType) in
             
-            guard sides > 1 else { return true }
+            guard i > 1 else { return true }
+            
+            let sides = Int(i)
             
             let result = Die.defaultRoller(sides: sides)
             

--- a/DiceKitTests/DieTests.swift
+++ b/DiceKitTests/DieTests.swift
@@ -167,10 +167,10 @@ extension Die_Test {
         }
         let die = try! Die(sides: 6)
         
-        let result = die.roll()
+        let roll = die.roll()
         
         expect(rollerCalledCount) == 1
-        expect(result) == stubResult
+        expect(roll.value) == stubResult
     }
     
     func test_roll_shouldPassInSidesToRoller() {
@@ -201,6 +201,19 @@ extension Die_Test {
         }
         
         expect(rollerCalledCount) == timesRolled
+    }
+    
+    func test_roll_shouldCreateRollProperly() {
+        let stubResult = 6
+        Die.roller = { sides in
+            return stubResult
+        }
+        let die = try! Die(sides: 8)
+        let expectedRoll = Die.Roll(die: die, value: stubResult)
+        
+        let roll = die.roll()
+        
+        expect(roll) == expectedRoll
     }
     
 }


### PR DESCRIPTION
Add `Die.Roll` type: a more formalized type around the result of `Die`'s `roll()`.
