### PR TITLE
Standardize naming of test cases

### DIFF
--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		533F88091B52B988003838C8 /* DiceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 533F87FE1B52B988003838C8 /* DiceKit.framework */; };
-		533F880E1B52B988003838C8 /* DieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F880D1B52B988003838C8 /* DieTests.swift */; };
+		533F880E1B52B988003838C8 /* Die_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F880D1B52B988003838C8 /* Die_Tests.swift */; };
 		533F88191B52BC6F003838C8 /* DiceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 533F88181B52BC6F003838C8 /* DiceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5379780B1B531B21005818EC /* Die.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5379780A1B531B21005818EC /* Die.swift */; };
 		538743871B5316BA00EB15C8 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 530FEDD11B530CAB00960BFD /* Nimble.framework */; };
@@ -16,7 +16,7 @@
 		53D05ED11B53417D007CE7FC /* Int+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D05ED01B53417D007CE7FC /* Int+Random.swift */; };
 		53D05EE21B535AD3007CE7FC /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53D05EE11B535AD3007CE7FC /* SwiftCheck.framework */; };
 		53D05EE31B535AF4007CE7FC /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 53D05EE11B535AD3007CE7FC /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		53D05EEC1B546C73007CE7FC /* Int+RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D05EEB1B546C73007CE7FC /* Int+RandomTests.swift */; };
+		53D05EEC1B546C73007CE7FC /* Int+Random_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D05EEB1B546C73007CE7FC /* Int+Random_Tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,7 +48,7 @@
 		533F87FE1B52B988003838C8 /* DiceKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DiceKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		533F88031B52B988003838C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		533F88081B52B988003838C8 /* DiceKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DiceKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		533F880D1B52B988003838C8 /* DieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DieTests.swift; sourceTree = "<group>"; };
+		533F880D1B52B988003838C8 /* Die_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Die_Tests.swift; sourceTree = "<group>"; };
 		533F880F1B52B988003838C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		533F88181B52BC6F003838C8 /* DiceKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DiceKit.h; sourceTree = "<group>"; };
 		5379780A1B531B21005818EC /* Die.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.swift; sourceTree = "<group>"; };
@@ -60,7 +60,7 @@
 		53D05EE81B53E6A0007CE7FC /* DiceKitTests.base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DiceKitTests.base.xcconfig; sourceTree = "<group>"; };
 		53D05EE91B53E6D3007CE7FC /* DiceKitTests.Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DiceKitTests.Debug.xcconfig; sourceTree = "<group>"; };
 		53D05EEA1B53E6E2007CE7FC /* DiceKitTests.Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DiceKitTests.Release.xcconfig; sourceTree = "<group>"; };
-		53D05EEB1B546C73007CE7FC /* Int+RandomTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+RandomTests.swift"; sourceTree = "<group>"; };
+		53D05EEB1B546C73007CE7FC /* Int+Random_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+Random_Tests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,8 +136,8 @@
 			isa = PBXGroup;
 			children = (
 				53D05ECF1B532208007CE7FC /* Supporting Files */,
-				533F880D1B52B988003838C8 /* DieTests.swift */,
-				53D05EEB1B546C73007CE7FC /* Int+RandomTests.swift */,
+				533F880D1B52B988003838C8 /* Die_Tests.swift */,
+				53D05EEB1B546C73007CE7FC /* Int+Random_Tests.swift */,
 			);
 			path = DiceKitTests;
 			sourceTree = "<group>";
@@ -289,8 +289,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53D05EEC1B546C73007CE7FC /* Int+RandomTests.swift in Sources */,
-				533F880E1B52B988003838C8 /* DieTests.swift in Sources */,
+				53D05EEC1B546C73007CE7FC /* Int+Random_Tests.swift in Sources */,
+				533F880E1B52B988003838C8 /* Die_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -1,5 +1,5 @@
 //
-//  DieTests.swift
+//  Die_Tests.swift
 //  DiceKitTests
 //
 //  Created by Brentley Jones on 7/12/15.
@@ -13,7 +13,7 @@ import SwiftCheck
 import DiceKit
 
 /// Tests the `Die` type
-class Die_Test: XCTestCase {
+class Die_Tests: XCTestCase {
     
     #if arch(i386) || arch(arm) // 32-bit
         typealias PositiveSidesType = UInt16
@@ -24,7 +24,7 @@ class Die_Test: XCTestCase {
 }
 
 // MARK: - init() tests
-extension Die_Test {
+extension Die_Tests {
     
     /// Tests that a die can have no sides.
     ///
@@ -107,7 +107,7 @@ extension Die_Test {
 }
 
 // MARK: - Equatatable
-extension Die_Test {
+extension Die_Tests {
     
     func test_shouldBeReflexive() {
         property["reflexive"] = forAll {
@@ -163,7 +163,7 @@ extension Die_Test {
 }
 
 // MARK: - roll() tests
-extension Die_Test {
+extension Die_Tests {
     
     func test_roll_shouldUseRoller() {
         var rollerCalledCount = 0
@@ -226,7 +226,7 @@ extension Die_Test {
 }
 
 // MARK: - defaultRoller tests
-extension Die_Test {
+extension Die_Tests {
 
     func test_RollerType_shouldReturn0For0Sides() {
         expect(Die.defaultRoller(sides: 0)) == 0

--- a/DiceKitTests/Int+Random_Tests.swift
+++ b/DiceKitTests/Int+Random_Tests.swift
@@ -1,5 +1,5 @@
 //
-//  Int+RandomTests.swift
+//  Int+Random_Tests.swift
 //  DiceKit
 //
 //  Created by Brentley Jones on 7/13/15.
@@ -13,7 +13,7 @@ import SwiftCheck
 @testable import DiceKit
 
 // TODO: Use generics to consolidate the tests
-class Int_RandomTests: XCTestCase {
+class Int_Random_Tests: XCTestCase {
     
     func test_UInt64_randomExtremes() {
         _ = UInt64.random(lower: UInt64.min, upper: UInt64.max)


### PR DESCRIPTION
Standardized the naming of the test cases, both in the filename and in the test case class names.

For the filename the full type name should be appended with `_Tests`. For the test case class name any illegal characters are simply replaced with `_`.

Filename: TypeTo.Be+Tested_Tests.swift
Test class name: TypeTo_Be_Tested_Tests
