### PR TITLE
Extract Die.Roll to separate file

### DIFF
--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		531084C31B5B0761008DD696 /* Die.Roll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084C11B5B0102008DD696 /* Die.Roll.swift */; };
 		533F88091B52B988003838C8 /* DiceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 533F87FE1B52B988003838C8 /* DiceKit.framework */; };
 		533F880E1B52B988003838C8 /* DieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F880D1B52B988003838C8 /* DieTests.swift */; };
 		533F88191B52BC6F003838C8 /* DiceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 533F88181B52BC6F003838C8 /* DiceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -45,6 +46,7 @@
 
 /* Begin PBXFileReference section */
 		530FEDD11B530CAB00960BFD /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		531084C11B5B0102008DD696 /* Die.Roll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.Roll.swift; sourceTree = "<group>"; };
 		533F87FE1B52B988003838C8 /* DiceKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DiceKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		533F88031B52B988003838C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		533F88081B52B988003838C8 /* DiceKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DiceKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -127,6 +129,7 @@
 				5379780C1B531B2A005818EC /* Supporting Files */,
 				533F88181B52BC6F003838C8 /* DiceKit.h */,
 				5379780A1B531B21005818EC /* Die.swift */,
+				531084C11B5B0102008DD696 /* Die.Roll.swift */,
 				53D05ED01B53417D007CE7FC /* Int+Random.swift */,
 			);
 			path = DiceKit;
@@ -280,6 +283,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				531084C31B5B0761008DD696 /* Die.Roll.swift in Sources */,
 				5379780B1B531B21005818EC /* Die.swift in Sources */,
 				53D05ED11B53417D007CE7FC /* Int+Random.swift in Sources */,
 			);

--- a/DiceKit/Die.Roll.swift
+++ b/DiceKit/Die.Roll.swift
@@ -1,0 +1,30 @@
+//
+//  Die.Roll.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 7/18/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import Foundation
+
+extension Die {
+    /**
+    The result of rolling a `Die`.
+    */
+    public struct Roll: Equatable {
+        
+        public let die: Die
+        public let value: Int
+        
+        public init(die: Die, value: Int) {
+            self.die = die
+            self.value = value
+        }
+    }
+}
+
+// MARK: - Equatable
+public func ==(lhs: Die.Roll, rhs: Die.Roll) -> Bool {
+    return lhs.die == rhs.die && lhs.value == rhs.value
+}

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -22,20 +22,6 @@ An imaginary die with `0` to `Int.max` sides. Default of 6 sides.
 public struct Die: Equatable {
     
     /**
-    The result of rolling a `Die`.
-    */
-    public struct Roll: Equatable {
-        
-        public let die: Die
-        public let value: Int
-        
-        public init(die: Die, value: Int) {
-            self.die = die
-            self.value = value
-        }
-    }
-    
-    /**
     A type that "rolls" an imaginary die with `sides` number of sides and returns the result.
     
     Passing a value less than `0` for `sides` is undefined.
@@ -74,8 +60,4 @@ public struct Die: Equatable {
 // MARK: - Equatable
 public func ==(lhs: Die, rhs: Die) -> Bool {
     return lhs.sides == rhs.sides
-}
-
-public func ==(lhs: Die.Roll, rhs: Die.Roll) -> Bool {
-    return lhs.die == rhs.die && lhs.value == rhs.value
 }


### PR DESCRIPTION
While nested types can sometimes be in the same file as the parent, once they need their own extensions things get messy. (Foreshadowing: `Die.Roll` will be conforming to some protocols soon.)
