### PR TITLE
Fix Xcode 7b4 compiling

### DIFF
--- a/DiceKit/AdditionExpression.swift
+++ b/DiceKit/AdditionExpression.swift
@@ -23,7 +23,7 @@ public struct AdditionExpression<LeftExpression: ExpressionType, RightExpression
 // MARK: - Expression
 extension AdditionExpression: ExpressionType {
     
-    typealias Result = AdditionExpressionResult<LeftExpression.Result, RightExpression.Result>
+    public typealias Result = AdditionExpressionResult<LeftExpression.Result, RightExpression.Result>
     
     public func evaluate() -> Result {
         let leftResult = leftAddend.evaluate()

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -92,7 +92,7 @@ extension Die {
 // MARK: - ExpressionType
 extension Die: ExpressionType {
     
-    typealias Result = Roll
+    public typealias Result = Roll
     
     public func evaluate() -> Roll {
         return roll()

--- a/DiceKit/ExpressionType.swift
+++ b/DiceKit/ExpressionType.swift
@@ -24,7 +24,7 @@ public protocol ExpressionType {
 
 extension Int: ExpressionType {
     
-    typealias Result = Int
+    public typealias Result = Int
     
     public func evaluate() -> Int {
         return self

--- a/DiceKit/MultiplicationExpression.swift
+++ b/DiceKit/MultiplicationExpression.swift
@@ -23,7 +23,7 @@ public struct MultiplicationExpression<LeftExpression: ExpressionType, RightExpr
 // MARK: - Expression
 extension MultiplicationExpression: ExpressionType {
     
-    typealias Result = MultiplicationExpressionResult<LeftExpression.Result, RightExpression.Result>
+    public typealias Result = MultiplicationExpressionResult<LeftExpression.Result, RightExpression.Result>
     
     public func evaluate() -> Result {
         let muliplierResult = multiplier.evaluate()

--- a/DiceKit/NegationExpression.swift
+++ b/DiceKit/NegationExpression.swift
@@ -21,7 +21,7 @@ public struct NegationExpression<BaseExpression: ExpressionType where BaseExpres
 // MARK: - Expression
 extension NegationExpression: ExpressionType {
     
-    typealias Result = NegationExpressionResult<BaseExpression.Result>
+    public typealias Result = NegationExpressionResult<BaseExpression.Result>
     
     public func evaluate() -> Result {
         return NegationExpressionResult(base.evaluate())


### PR DESCRIPTION
Protocol associated type typealias needs to be public when protocol is public.
