### PR TITLE
Clean up Die.swift and Die.Roll.swift

### DIFF
--- a/DiceKit/Die.Roll.swift
+++ b/DiceKit/Die.Roll.swift
@@ -9,9 +9,8 @@
 import Foundation
 
 extension Die {
-    /**
-    The result of rolling a `Die`.
-    */
+
+    /// The result of rolling a `Die`.
     public struct Roll: Equatable {
         
         public let die: Die
@@ -22,6 +21,7 @@ extension Die {
             self.value = value
         }
     }
+    
 }
 
 // MARK: - ExpressionResultType

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// An imaginary die with `0` to `Int.max` sides. Default of 6 sides.
+/// An imaginary die with `0` to `Int.max` sides. Default value is `defaultSides`.
 public struct Die: Equatable {
     
     // TODO: Determine if there is a better way to do this.
@@ -16,8 +16,9 @@ public struct Die: Equatable {
     public static var roller = defaultRoller
     
     public let sides: Int
+    public static let defaultSides = 6
     
-    public init(sides: Int = 6) {
+    public init(sides: Int = defaultSides) {
         self.sides = sides
     }
     

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 
-/**
-An imaginary die with `0` to `Int.max` sides. Default of 6 sides. 
-*/
+/// An imaginary die with `0` to `Int.max` sides. Default of 6 sides.
 public struct Die: Equatable {
     
     // TODO: Determine if there is a better way to do this.
@@ -23,12 +21,10 @@ public struct Die: Equatable {
         self.sides = sides
     }
     
-    /**
-    Rolls the die and returns the result as a `Die.Roll`.
-    
-    - returns: A `Die.Roll` initiated with `self` and the value determined by
-        `Die.roller` by passing in `self.sides` for `sides`.
-    */
+    /// Rolls the die and returns the result as a `Die.Roll`.
+    ///
+    /// - returns: A `Die.Roll` initiated with `self` and the value determined by
+    ///     `Die.roller` by passing in `self.sides` for `sides`.
     public func roll() -> Roll {
         let result = Die.roller(sides: sides)
         return Roll(die: self, value: result)


### PR DESCRIPTION
Changed doc strings to their proper format. Also gave the `Die` type a `public static defaultDie` property. 
