### PR TITLE
Allow `Int` to be used in addition and multiplication operators

### DIFF
--- a/DiceKit/AdditionExpression.swift
+++ b/DiceKit/AdditionExpression.swift
@@ -58,5 +58,13 @@ public func == <L, R>(lhs: AdditionExpression<L, R>, rhs: AdditionExpression<L, 
 // MARK: - Operators
 
 public func + <L: ExpressionType, R: ExpressionType where L: Equatable, R: Equatable>(lhs: L, rhs: R) -> AdditionExpression<L, R> {
-    return AdditionExpression(lhs,rhs)
+    return AdditionExpression(lhs, rhs)
+}
+
+public func + <R: ExpressionType where R: Equatable>(lhs: Int, rhs: R) -> AdditionExpression<Constant, R> {
+    return AdditionExpression(Constant(lhs), rhs)
+}
+
+public func + <L: ExpressionType where L: Equatable>(lhs: L, rhs: Int) -> AdditionExpression<L, Constant> {
+    return AdditionExpression(lhs, Constant(rhs))
 }

--- a/DiceKit/MultiplicationExpression.swift
+++ b/DiceKit/MultiplicationExpression.swift
@@ -50,3 +50,11 @@ public func == <L, R>(lhs: MultiplicationExpression<L, R>, rhs: MultiplicationEx
 public func * <L: ExpressionType, R: ExpressionType where L: Equatable, R: Equatable>(lhs: L, rhs: R)-> MultiplicationExpression<L, R> {
     return MultiplicationExpression(lhs, rhs)
 }
+
+public func * <R: ExpressionType where R: Equatable>(lhs: Int, rhs: R)-> MultiplicationExpression<Constant, R> {
+    return MultiplicationExpression(Constant(lhs), rhs)
+}
+
+public func * <L: ExpressionType where L: Equatable>(lhs: L, rhs: Int)-> MultiplicationExpression<L, Constant> {
+    return MultiplicationExpression(lhs, Constant(rhs))
+}

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -122,17 +122,16 @@ extension AdditionExpression_Tests {
 // MARK: - Operators
 extension AdditionExpression_Tests {
     
-    func test_operator_shouldWorkWithIntAndDie() {
-        property("Constant + Die returns correct AdditionExpression") <- forAll {
+    func test_operator_shouldWorkWithIntAndExpression() {
+        property("Int + Expression and Expression + Int returns correct AdditionExpression") <- forAll {
             (a: Int, b: Int) in
             
-            let constant = c(a)
             let die = d(b)
-            let expectedExpression1 = AdditionExpression(constant, die)
-            let expectedExpression2 = AdditionExpression(die, constant)
+            let expectedExpression1 = AdditionExpression(c(a), die)
+            let expectedExpression2 = AdditionExpression(die, c(a))
             
-            let expression1 = constant + die
-            let expression2 = die + constant
+            let expression1 = a + die
+            let expression2 = die + a
             
             let test1 = (expression1 == expectedExpression1)
             let test2 = (expression2 == expectedExpression2)
@@ -141,8 +140,8 @@ extension AdditionExpression_Tests {
         }
     }
     
-    func test_operator_shouldWorkWithDieAndDie() {
-        property("Die + Die returns correct AdditionExpresson") <- forAll {
+    func test_operator_shouldWorkWithExpressionAndExpression() {
+        property("Expression + Expression returns correct AdditionExpresson") <- forAll {
             (a: Int, b: Int) in
             
             let leftDie = d(a)
@@ -150,20 +149,6 @@ extension AdditionExpression_Tests {
             let expectedExpression = AdditionExpression(leftDie, rightDie)
             
             let expression = leftDie + rightDie
-        
-            return expression == expectedExpression
-        }
-    }
-    
-    func test_operator_shouldWorkWithMultiplicationExpressions() {
-        property("MultiplicationExpression + Constant returns correct AdditionExpression") <- forAll {
-            (m: Int, n: Int, o: Int) in
-            
-            let leftExpression = c(m) * d(n)
-            let rightExpression = c(o)
-            let expectedExpression = AdditionExpression(leftExpression, rightExpression)
-            
-            let expression = leftExpression + rightExpression
         
             return expression == expectedExpression
         }

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -136,17 +136,16 @@ extension MultiplicationExpression_Tests {
 // MARK: - Operators
 extension MultiplicationExpression_Tests {
     
-    func test_operator_shouldWorkWithIntAndDie() {
-        property("Int * Die returns correct MultiplicationExpression") <- forAll {
+    func test_operator_shouldWorkWithIntAndExpression() {
+        property("Int * Expression and Expression * Int returns correct MultiplicationExpression") <- forAll {
             (a: Int, b: Int) in
             
-            let constant = c(a)
             let die = d(b)
-            let expectedExpression1 = MultiplicationExpression(constant, die)
-            let expectedExpression2 = MultiplicationExpression(die, constant)
+            let expectedExpression1 = MultiplicationExpression(c(a), die)
+            let expectedExpression2 = MultiplicationExpression(die, c(a))
             
-            let expression1 = constant * die
-            let expression2 = die * constant
+            let expression1 = a * die
+            let expression2 = die * a
         
             let test1 = (expression1 == expectedExpression1)
             let test2 = (expression2 == expectedExpression2)
@@ -154,8 +153,8 @@ extension MultiplicationExpression_Tests {
         }
     }
     
-    func test_operator_shouldWorkWithDieAndDie() {
-        property("Die * Die returns correct MultiplicationExpression") <- forAll {
+    func test_operator_shouldWorkWithExpressionAndExpression() {
+        property("Expression * Expression returns correct MultiplicationExpression") <- forAll {
             (a: Int, b: Int) in
             
             let leftDie = d(a)

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -98,32 +98,6 @@ extension NegationExpression_Tests {
 // MARK: - Operators
 extension NegationExpression_Tests {
     
-    func test_operator_shouldWorkOnConstant() {
-        property("-Constant should make correct NegationExpression") <- forAll {
-            (a: Int) in
-            
-            let constant = c(a)
-            let expectedExpression = NegationExpression(constant)
-            
-            let expression = -constant
-            
-            return expression == expectedExpression
-        }
-    }
-    
-    func test_operator_shouldWorkOnDie() {
-        property("-Die should make correct NegationExpression") <- forAll {
-            (a: Int) in
-            
-            let die = d(a)
-            let expectedExpression = NegationExpression(die)
-            
-            let expression = -die
-            
-            return expression == expectedExpression
-        }
-    }
-    
     func test_operator_shouldWorkOnExpression() {
         property("-Expression should make correct NegationExpression") <- forAll {
             (m: Int, n: Int, o: Int) in

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ let rollWasFromD11 = roll.die == d(11) // true
 
 ```swift
 // 2d20 + 8
-let expression = c(2) * d(20) + c(8)
+let expression = 2 * d(20) + 8
 
 // Result
 let result = expression.evaluate()

--- a/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
@@ -10,7 +10,7 @@ import DiceKit
 let expression = AdditionExpression(MultiplicationExpression(c(2), Die(sides: 20)), c(8))
 
 //: Wow! That's a little verbose. Luckily there are several operators for convenience. Here is an equivalent expression:
-let expression2 = c(2) * d(20) + c(8)
+let expression2 = 2 * d(20) + 8
 expression == expression2
 
 //: Unlike in programming, an expression isn't evaluated by automatically. An expression holds the blueprint for how to determine a result. To evaluate the expression and get a result call `evaluate()` on it. The returned type will conform to `ExpressionResultType`, the exact type being the associated `ExpressionType.Result` type of the expression.


### PR DESCRIPTION
Also remove unneeded tests (all expressions work, by proof of compiler and induction... no need to test the different expressions in the other expressions).
