### PR TITLE
Add CustomDebugStringConvertible and CustomStringConvertible conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   [Brentley Jones](https://github.com/brentleyjones)
   [#83](https://github.com/TabletopAssistant/DiceKit/pull/83)
 
+- :mag: Add `CustomStringLiteral` and `CustomDebugStringLiteral` conformance to base types.  
+  [Jonathan Hoffman](https://github.com/JonathanHoffman)
+  [#55](https://github.com/TabletopAssistant/DiceKit/pull/55)
+
 ## 0.1: It Starts with a Single Die (2015-07-25)
 
 - :game_die: Support rolling individual dice.  

--- a/DiceKit/AdditionExpression.swift
+++ b/DiceKit/AdditionExpression.swift
@@ -39,6 +39,26 @@ extension AdditionExpression: ExpressionType {
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension AdditionExpression: CustomStringConvertible {
+    
+    public var description: String {
+        return "\(leftAddend) + \(rightAddend)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension AdditionExpression: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "\(String(reflecting: leftAddend)) + \(String(reflecting: rightAddend))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 private func equate<L, R>(lhs: AdditionExpression<L, R>, _ rhs: AdditionExpression<L, R>) -> Bool {

--- a/DiceKit/AdditionExpressionResult.swift
+++ b/DiceKit/AdditionExpressionResult.swift
@@ -20,6 +20,26 @@ public struct AdditionExpressionResult<LeftAddendResult: protocol<ExpressionResu
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension AdditionExpressionResult: CustomStringConvertible {
+    
+    public var description: String {
+        return "\(leftAddendResult) + \(rightAddendResult)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension AdditionExpressionResult: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "\(String(reflecting: leftAddendResult)) + \(String(reflecting: rightAddendResult))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == <L, R>(lhs: AdditionExpressionResult<L,R>, rhs: AdditionExpressionResult<L,R>) -> Bool {

--- a/DiceKit/Constant.swift
+++ b/DiceKit/Constant.swift
@@ -24,6 +24,26 @@ public func c(value: Int) -> Constant {
     return Constant(value)
 }
 
+// MARK: CustomStringConvertible
+
+extension Constant: CustomStringConvertible {
+    
+    public var description: String {
+        return "\(value)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension Constant: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "Constant(\(value))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == (lhs: Constant, rhs: Constant) -> Bool {

--- a/DiceKit/Die.Roll.swift
+++ b/DiceKit/Die.Roll.swift
@@ -30,6 +30,28 @@ extension Die.Roll: ExpressionResultType {
     // Already conforms because of `value`
 }
 
+// MARK: - CustomStringConvertible
+
+extension Die.Roll: CustomStringConvertible {
+    
+    public var description: String {
+        get {
+            return "\(value)|\(die.sides)"
+        }
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension Die.Roll: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "\(String(reflecting: die)).Roll(\(value))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == (lhs: Die.Roll, rhs: Die.Roll) -> Bool {

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -128,6 +128,30 @@ extension Die: ExpressionType {
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension Die: CustomStringConvertible {
+    
+    public var description: String {
+        if sides < 0 {
+            return "d(\(sides))"
+        } else {
+            return "d\(sides)"
+        }
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension Die: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "Die(\(sides))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == (lhs: Die, rhs: Die) -> Bool {

--- a/DiceKit/MultiplicationExpression.swift
+++ b/DiceKit/MultiplicationExpression.swift
@@ -43,6 +43,32 @@ extension MultiplicationExpression: ExpressionType {
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension MultiplicationExpression: CustomStringConvertible {
+    
+    public var description: String {
+        if multiplier is Constant && multiplicand is Die {
+            return "\(multiplier)\(multiplicand)"
+        } else if multiplicand is Die {
+            return "(\(multiplier))\(multiplicand)"
+        } else {
+            return "(\(multiplier) * \(multiplicand))"
+        }
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension MultiplicationExpression: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "(\(String(reflecting: multiplier)) * \(String(reflecting: multiplicand)))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == <L, R>(lhs: MultiplicationExpression<L, R>, rhs: MultiplicationExpression<L, R>) -> Bool {

--- a/DiceKit/MultiplicationExpressionResult.swift
+++ b/DiceKit/MultiplicationExpressionResult.swift
@@ -24,6 +24,33 @@ public struct MultiplicationExpressionResult<MultiplierResult: protocol<Expressi
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension MultiplicationExpressionResult: CustomStringConvertible {
+    
+    public var description: String {
+        let multiplicandResultsSign = negateMultiplicandResults ? "-" : ""
+        let multiplicandStrings = multiplicandResults.map { String($0) }
+        let multiplicandResultsDescription = " + ".join(multiplicandStrings)
+        return "((\(multiplierResult)) *> \(multiplicandResultsSign)(\(multiplicandResultsDescription)))"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension MultiplicationExpressionResult: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        let multiplicandResultsSign = negateMultiplicandResults ? "-" : ""
+        let multiplierResultDebugString = String(reflecting: multiplierResult)
+        let multiplicandDebugStrings = multiplicandResults.map { String(reflecting: $0) }
+        let multiplicandResultsDebugDescription = " + ".join(multiplicandDebugStrings)
+        return "((\(multiplierResultDebugString)) *> \(multiplicandResultsSign)(\(multiplicandResultsDebugDescription)))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == <M, R>(lhs: MultiplicationExpressionResult<M,R>, rhs: MultiplicationExpressionResult<M,R>) -> Bool {

--- a/DiceKit/NegationExpression.swift
+++ b/DiceKit/NegationExpression.swift
@@ -34,6 +34,26 @@ extension NegationExpression: ExpressionType {
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension NegationExpression: CustomStringConvertible {
+    
+    public var description: String {
+        return "-\(base)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension NegationExpression: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "-\(String(reflecting: base))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == <E>(lhs: NegationExpression<E>, rhs: NegationExpression<E>) -> Bool {

--- a/DiceKit/NegationExpressionResult.swift
+++ b/DiceKit/NegationExpressionResult.swift
@@ -18,6 +18,26 @@ public struct NegationExpressionResult<BaseResult: protocol<ExpressionResultType
     
 }
 
+// MARK: - CustomStringConvertible
+
+extension NegationExpressionResult: CustomStringConvertible {
+    
+    public var description: String {
+        return "-\(base)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension NegationExpressionResult: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "-\(String(reflecting: base))"
+    }
+    
+}
+
 // MARK: - Equatable
 
 public func == <B>(lhs: NegationExpressionResult<B>, rhs: NegationExpressionResult<B>) -> Bool {

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -80,3 +80,33 @@ extension AdditionExpressionResult_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension AdditionExpressionResult_Tests {
+    
+    func test_CustomDebuStringConvertible() {
+        let expression = d(10) + 5
+        let evaluation = expression.evaluate()
+        let expected = "Die(10).Roll(\(evaluation.leftAddendResult.value)) + Constant(5)"
+        
+        let result = String(reflecting: evaluation)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// Mark: - CustomStringConvertible
+extension AdditionExpressionResult_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = d(10) + 5
+        let evaluation = expression.evaluate()
+        let expected = "\(evaluation.leftAddendResult.value)|10 + 5"
+        
+        let result = String(evaluation)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -139,3 +139,31 @@ extension AdditionExpression_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension AdditionExpression_Tests {
+    
+    func test_CustomDebugStringConvertible() {
+        let expression = d(8) + 2
+        let expected = "Die(8) + Constant(2)"
+        
+        let result = String(reflecting: expression)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+extension AdditionExpression_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = d(20) + d(4)
+        let expected = "d20 + d4"
+        
+        let result = String(expression)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -431,3 +431,52 @@ extension Die_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension Die_Tests {
+    
+    func test_die_customDebugStringConvertible() {
+        let die = d(6)
+        let expected = "Die(6)"
+        
+        let result = String(reflecting: die)
+        
+        expect(result) == expected
+    }
+    
+    func test_roll_customDebugStringConvertible() {
+        let die = d(4)
+        let roll = die.roll()
+        let expectedResult = "Die(4).Roll(\(roll.value))"
+        
+        let result = String(reflecting: roll)
+        
+        expect(result) == expectedResult
+    }
+    
+}
+
+//MARK: - CustomString Convertible
+extension Die_Tests {
+    
+    func test_die_customStringConvertible() {
+        let die = d(6)
+        let expected = "d6"
+        
+        let result = String(die)
+        
+        expect(result) == expected
+    }
+    
+    func test_roll_customStringConvertible() {
+        let die = d(6)
+        let roll = die.roll()
+        let val = roll.value
+        let expected = "\(val)|6"
+        
+        let result = String(roll)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -151,4 +151,3 @@ extension MultiplicationExpressionResult_Tests {
     }
     
 }
-   

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -121,3 +121,34 @@ extension MultiplicationExpressionResult_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension MultiplicationExpressionResult_Tests {
+    
+    func test_CustomDebugStringConvertible() {
+        let expression = 2 * d(10)
+        let evaluation = expression.evaluate()
+        let expected = "((Constant(2)) *> (\(String(reflecting: evaluation.multiplicandResults[0])) + \(String(reflecting: evaluation.multiplicandResults[1]))))"
+        
+        let result = String(reflecting: evaluation)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// MARK: = CustomStringConvertible
+extension MultiplicationExpressionResult_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = 2 * d(10)
+        let evaluation = expression.evaluate()
+        let expected = "((2) *> (\(evaluation.multiplicandResults[0]) + \(evaluation.multiplicandResults[1])))"
+        
+        let result = String(evaluation)
+        
+        expect(result) == expected
+    }
+    
+}
+   

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -144,3 +144,31 @@ extension MultiplicationExpression_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension MultiplicationExpression_Tests {
+    
+    func test_CustomDebugStringConvertible() {
+        let expression = 2 * d(10)
+        let expected = "(Constant(2) * Die(10))"
+        
+        let result = String(reflecting: expression)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+extension MultiplicationExpression_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = 2 * d(10)
+        let expected = "2d10"
+        
+        let result = String(expression)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/DiceKitTests/NegationExpressionResult_Tests.swift
+++ b/DiceKitTests/NegationExpressionResult_Tests.swift
@@ -76,3 +76,33 @@ extension NegationExpressionResult_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension NegationExpressionResult_Tests {
+    
+    func test_customDebugStringConvertible() {
+        let expression = -(d(8))
+        let evaluation = expression.evaluate()
+        let expected = "-Die(8).Roll(\(evaluation.base.value))"
+        
+        let result = String(reflecting: evaluation)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+extension NegationExpressionResult_Tests {
+    
+    func test_customStringConvertible() {
+        let expression = -(d(8))
+        let evaluation = expression.evaluate()
+        let expected = "-\(evaluation.base)"
+        
+        let result = String(evaluation)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -106,3 +106,32 @@ extension NegationExpression_Tests {
     }
     
 }
+
+
+// MARK: - CustomDebugStringConvertible
+extension NegationExpression_Tests {
+    
+    func test_CustomDebugStringConvertible() {
+        let expression = -(d(8))
+        let expected = "-Die(8)"
+        
+        let result = String(reflecting: expression)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+extension NegationExpression_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = -(d(8))
+        let expected = "-d8"
+        
+        let result = String(expression)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/TomeOfKnowledge.playground/Pages/Dice.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Dice.xcplaygroundpage/Contents.swift
@@ -33,6 +33,11 @@ let d4Value = d4Result.value
 d6Result.die == d6
 d4Result.die == Die(sides: 4)
 
+//: If you really want flexibility in the way dice work, you can assign new rollers to the `Die.roller` property. Rollers define the range of outcomes that a die can have. When you roll a die, the result is made by passing that die's `sides` property to the roller. The default is `signedClosedRoller`, which can have a positive or negative number of sides. Another available roller is `unsignedRoller`, which will cause the dice to return 0 when sides <= 0.
+Die.roller = Die.unsignedRoller
+let unsignedDie = d(-10)
+let unsignedResult = unsignedDie.roll()
+let unsignedValue = unsignedResult.value
 
 //: Now that we have a grasp on single dice, let's explore [expressions](Expressions), which allows for combining dice and constants with various operations such as multiplication and addition.
 //:

--- a/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/Contents.swift
@@ -1,0 +1,41 @@
+//: ## Exploring Expressions
+//: 
+//: Our expressions are more robust than what is needed for typical tabletop play. In fact, our generic expression system is capable of modeling expressions that would otherwise be considered too cumbersome or complex to physically roll. In order to help developers understand what their expressions actually represent, we have added various tools to make working with expressions as easy as possible.
+import DiceKit
+
+//: Lets start with the negative-sided die.
+let negativeDie = d(-12)
+
+//: A die with negative sides by default has results in the range `-sides...-1` (but you can assign different rollers to `Die.roller`). We have two ways to represent an expression as a string.
+//: * `normalString` is the string returned from `negativeDie.description`. Our descriptions are intended to be readable and closely match regular dice notation. This also happens to be the text that playgrounds display to the right.
+//: * `verboseString` is what is returned from `negativeDie.debugDescription`. These strings tend to do less to make the result readable, and are intended to show exactly what types are used.
+let normalString = String(negativeDie)
+let verboseString = String(reflecting: negativeDie)
+
+//: When we look at the `description` of a die roll, we seperate the rolled value from the total number of sides with a |. So a d6 that rolled a 3 would be written as 3|6. Or with our special negative die:
+let negativeResult = negativeDie.roll()
+
+//: Multiplication expressions are particularly interesting to look at. We will make one multiplication expression and see what happens when we make a third multiplication expression from the first one and a die.
+let oneD2 = 1 * d(2)
+let d3 = d(3)
+
+//: `oneD2` is of the type `MultiplicationExpression<Constant, Die>` because it is made by multiplying a `Consant` (the expression type `Int` is converted to) by a `Die`.
+oneD2 is MultiplicationExpression<Constant, Die>
+
+//: We can make a new multiplication expression with these two expressions. This expression works like a "normal" multiplication expression, but the multiplier is 1 half the time, and 2 the other half of the time.
+let oneD2d3 = oneD2 * d3
+
+//: When we `evaluate()` a multiplication expression, we can see what each side of the expression evaluated to. First, an easy case. This result type has a `.multiplierResult` and  `.multiplicandResults`. The multiplier is always 2, because it is a constant. The multiplicand is evaluated and summed n number of times to give the result, where n is the multiplier result. We seperate the multiplier and multiplicand with the symbol `*>` in the description, which says that the result of the left hand side is the length of the right hand side.
+let twoD20 = 2 * d(20)
+let twoD20result = twoD20.evaluate()
+
+//: Now lets evaluate our compound multiplication expression. The leftmost term is the multiplier for 1d2. It must always be 1. The middle term is either a 1|2 or a 2|2, depending on what the d2 rolled. Finally, the rightmost term is either a single d3 roll or the sum of two d3 rolls, depending on what the d2 rolled.
+let oneD2d3result = oneD2d3.evaluate()
+
+//: The result of the expression is always the sum of the rightmost term.
+let value = oneD2d3result.value
+
+//: Try making more expressions in this playground. There is no limitation on what expression types you can put together to make a new expression. If your expression gets too complicated to easily tell its type, use the `dump()` function to investigate it in the console window.
+
+//: [Previous](@previous)
+//: [Next](@next)

--- a/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/timeline.xctimeline
+++ b/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
@@ -2,8 +2,6 @@
 //:
 //: Similar to programming expressions you can create expressions in DiceKit that represent the combination of other expressions. Anything that conforms to `ExpressionResultType` is an expression, which means that `Die` and `Int` are also expressions (which is useful, otherwise they would be pretty worthless).
 //:
-//: > **Note:**
-//: > Expressions are currently a little rough around the edges. In the 0.2 release we plan on cleaning them up.
 import DiceKit
 
 //: Let's start with creating an expression that represents `2d20+8`:

--- a/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/timeline.xctimeline
+++ b/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=142&amp;EndingColumnNumber=10&amp;EndingLineNumber=6&amp;StartingColumnNumber=5&amp;StartingLineNumber=6&amp;Timestamp=459365845.065094"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=142&amp;EndingColumnNumber=10&amp;EndingLineNumber=4&amp;StartingColumnNumber=5&amp;StartingLineNumber=4&amp;Timestamp=460827343.4464"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/TomeOfKnowledge.playground/contents.xcplayground
+++ b/TomeOfKnowledge.playground/contents.xcplayground
@@ -3,6 +3,7 @@
     <pages>
         <page name='Dice'/>
         <page name='Expressions'/>
+        <page name='Exploring Expressions'/>
         <page name='Probability'/>
     </pages>
 </playground>


### PR DESCRIPTION
Progress! 

TODO: 
- [x] implement `CustomStringConvertible` and `CustomDebugStringConvertible` to the Expression types.
- [x] write a playground page exploring these types, their strings, and their developer friendliness. (what would you like to see in such a page?) 

Closes #50 
