### PR TITLE
Make `Outcome` in `ProbabilityMass` & `FrequencyDistribution` generic

### DIFF
--- a/DiceKit/AdditionExpression.swift
+++ b/DiceKit/AdditionExpression.swift
@@ -33,7 +33,7 @@ extension AdditionExpression: ExpressionType {
         return Result(leftResult, rightResult)
     }
     
-    public var probabilityMass: ProbabilityMass {
+    public var probabilityMass: ExpressionProbabilityMass {
         return leftAddend.probabilityMass && rightAddend.probabilityMass
     }
     

--- a/DiceKit/Constant.swift
+++ b/DiceKit/Constant.swift
@@ -52,8 +52,9 @@ extension Constant: ExpressionType {
         return self
     }
     
-    public var probabilityMass: ProbabilityMass {
-        return ProbabilityMass(value)
+    public var probabilityMass: ExpressionProbabilityMass {
+        let probMassValue = ExpressionProbabilityMass.Outcome(value)
+        return ProbabilityMass(probMassValue)
     }
     
 }

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -109,17 +109,19 @@ extension Die: ExpressionType {
         return roll()
     }
     
-    public var probabilityMass: ProbabilityMass {
+    public var probabilityMass: ExpressionProbabilityMass {
         guard sides != 0 else {
             return ProbabilityMass.zero
         }
         
-        var frequenciesPerOutcome = FrequencyDistribution.FrequenciesPerOutcome()
-        let outcomePerValue = 1.0/ProbabilityMass.Probability(abs(sides))
-        let range = sides < 0 ? sides...1 : 1...sides
+        var frequenciesPerOutcome = FrequencyDistribution<ExpressionProbabilityMass.Outcome>.FrequenciesPerOutcome()
+        let frequencyPerOutcome = 1.0/ExpressionProbabilityMass.Probability(abs(sides))
+        let minAnchor = ExpressionProbabilityMass.Outcome(1)
+        let sidesAnchor = ExpressionProbabilityMass.Outcome(sides)
+        let range = sides < 0 ? sidesAnchor...minAnchor : minAnchor...sidesAnchor
         
         for value in range {
-            frequenciesPerOutcome[value] = outcomePerValue
+            frequenciesPerOutcome[value] = frequencyPerOutcome
         }
         
         return ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome), normalize: false)

--- a/DiceKit/FrequencyDistributionIndex.swift
+++ b/DiceKit/FrequencyDistributionIndex.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Brentley Jones. All rights reserved.
 //
 
-public struct FrequencyDistributionIndex: ForwardIndexType {
+public struct FrequencyDistributionIndex<Outcome: FrequencyDistributionValueType>: ForwardIndexType {
     
-    typealias OrderedOutcomes = [FrequencyDistribution.Outcome]
+    typealias OrderedOutcomes = [Outcome]
     
     let index: Int
     let orderedOutcomes: OrderedOutcomes
@@ -26,7 +26,7 @@ public struct FrequencyDistributionIndex: ForwardIndexType {
         self.orderedOutcomes = orderedOutcomes
     }
     
-    var value: FrequencyDistribution.Outcome? {
+    var value: Outcome? {
         guard index >= 0 && index < orderedOutcomes.count else {
             return nil
         }
@@ -47,6 +47,6 @@ public struct FrequencyDistributionIndex: ForwardIndexType {
 
 // MARK: - Equatable
 
-public func == (lhs: FrequencyDistributionIndex, rhs: FrequencyDistributionIndex) -> Bool {
+public func == <V>(lhs: FrequencyDistributionIndex<V>, rhs: FrequencyDistributionIndex<V>) -> Bool {
     return lhs.index == rhs.index && lhs.orderedOutcomes == rhs.orderedOutcomes
 }

--- a/DiceKit/MultiplicationExpression.swift
+++ b/DiceKit/MultiplicationExpression.swift
@@ -37,7 +37,7 @@ extension MultiplicationExpression: ExpressionType {
         return Result(multiplierResult: muliplierResult, multiplicandResults: multiplicandResult)
     }
     
-    public var probabilityMass: ProbabilityMass {
+    public var probabilityMass: ExpressionProbabilityMass {
         return multiplier.probabilityMass * multiplicand.probabilityMass
     }
     

--- a/DiceKit/NegationExpression.swift
+++ b/DiceKit/NegationExpression.swift
@@ -28,7 +28,7 @@ extension NegationExpression: ExpressionType {
         return Result(base.evaluate())
     }
     
-    public var probabilityMass: ProbabilityMass {
+    public var probabilityMass: ExpressionProbabilityMass {
         return -base.probabilityMass
     }
     

--- a/DiceKit/ProbabilisticExpressionType.swift
+++ b/DiceKit/ProbabilisticExpressionType.swift
@@ -8,9 +8,11 @@
 
 import Foundation
 
+public typealias ExpressionProbabilityMass = ProbabilityMass<Int>
+
 public protocol ProbabilisticExpressionType {
     
-    var probabilityMass: ProbabilityMass { get }
+    var probabilityMass: ExpressionProbabilityMass { get }
     
     /// Returns `true` if both `ProbabilisticExpressionType`s have approximately
     /// same chance for each respective outcome.

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -419,9 +419,14 @@ extension Die_Tests {
                 return probMass == ProbabilityMass.zero
             }
             
-            let outcomePerValue = 1.0/ProbabilityMass.Probability(abs(sides))
-            let range = sides < 0 ? sides...1 : 1...sides
-            let inverseRange = inverseSides < 0 ? inverseSides...1 : 1...inverseSides
+            typealias PM = ExpressionProbabilityMass
+            
+            let outcomePerValue = 1.0/PM.Probability(abs(sides))
+            let minAnchor = PM.Outcome(1)
+            let sidesAnchor = PM.Outcome(sides)
+            let inverseSidesAnchor = PM.Outcome(inverseSides)
+            let range = sides < 0 ? sidesAnchor...minAnchor : minAnchor...sidesAnchor
+            let inverseRange = inverseSides < 0 ? inverseSidesAnchor...minAnchor : minAnchor...inverseSidesAnchor
             
             for value in range {
                 if probMass[value]! != outcomePerValue {

--- a/DiceKitTests/FrequencyDistributionIndex_Tests.swift
+++ b/DiceKitTests/FrequencyDistributionIndex_Tests.swift
@@ -15,7 +15,7 @@ import SwiftCheck
 /// Tests the `FrequencyDistributionIndex` type
 class FrequencyDistributionIndex_Tests: XCTestCase {
     
-    typealias SwiftCheckOrderedOutcome = SetOf<FrequencyDistribution.Outcome>
+    typealias SwiftCheckOrderedOutcome = SetOf<FrequencyDistribution<Int>.Outcome>
     
 }
 
@@ -129,7 +129,7 @@ extension FrequencyDistributionIndex_Tests {
     
     func test_startIndex_shouldBeSetupCorrectly() {
         property("startIndex") <- forAll {
-            (a: SetOf<FrequencyDistribution.Outcome>) in
+            (a: SwiftCheckOrderedOutcome) in
             
             let a = a.getSet
             
@@ -147,7 +147,7 @@ extension FrequencyDistributionIndex_Tests {
     
     func test_endIndex_shouldBeSetupCorrectly() {
         property("endIndex") <- forAll {
-            (a: SetOf<FrequencyDistribution.Outcome>) in
+            (a: SwiftCheckOrderedOutcome) in
             
             let a = a.getSet
             
@@ -165,7 +165,7 @@ extension FrequencyDistributionIndex_Tests {
     
     func test_value_shouldReturnValueForValidIndex() {
         property("value with valid index") <- forAll {
-            (a: SetOf<FrequencyDistribution.Outcome>) in
+            (a: SwiftCheckOrderedOutcome) in
             
             let a = a.getSet
             
@@ -187,7 +187,7 @@ extension FrequencyDistributionIndex_Tests {
     
     func test_value_shouldReturnNilForInvalidIndex() {
         property("value with invalid index") <- forAll {
-            (a: SetOf<FrequencyDistribution.Outcome>) in
+            (a: SwiftCheckOrderedOutcome) in
             
             let a = a.getSet
             

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -15,7 +15,7 @@ import DiceKit
 /// Tests the `FrequencyDistribution` type
 class FrequencyDistribution_Tests: XCTestCase {
     
-    typealias SwiftCheckFrequenciesPerOutcome = DictionaryOf<FrequencyDistribution.Outcome, FrequencyDistribution.Frequency>
+    typealias SwiftCheckFrequenciesPerOutcome = DictionaryOf<FrequencyDistribution<Int>.Outcome, FrequencyDistribution<Int>.Frequency>
 
 }
 
@@ -93,10 +93,10 @@ extension FrequencyDistribution_Tests {
     func test_indexable_forIn() {
         // TODO: SwiftCheck
         let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1, 2:1, 3:4, 6:1]
-        let expectedElements: [FrequencyDistribution._Element] = [(1, 1), (2, 1), (3, 4), (6, 1)]
+        let expectedElements: [FrequencyDistribution<Int>._Element] = [(1, 1), (2, 1), (3, 4), (6, 1)]
         let freqDist = FrequencyDistribution(frequenciesPerOutcome)
         
-        var elements: [FrequencyDistribution._Element] = []
+        var elements: [FrequencyDistribution<Int>._Element] = []
         for element in freqDist {
             elements.append(element)
         }
@@ -286,7 +286,7 @@ extension FrequencyDistribution_Tests {
     
     func test_power_shouldReturnMultiplicativeIdentityFor0() {
         let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [2:2.0, 3:2.0, 6:1.0]
-        let expected = FrequencyDistribution.multiplicativeIdentity
+        let expected = FrequencyDistribution<Int>.multiplicativeIdentity
         let x = FrequencyDistribution(frequenciesPerOutcome)
         
         let freqDist = x.power(0)
@@ -327,7 +327,7 @@ extension FrequencyDistribution_Tests {
         let yFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [2:2.0, 3:2.0, 7:1.0]
         let x = FrequencyDistribution(xFrequenciesPerOutcome)
         let y = FrequencyDistribution(yFrequenciesPerOutcome)
-        let expected = xFrequenciesPerOutcome.reduce(FrequencyDistribution.additiveIdentity) {
+        let expected = xFrequenciesPerOutcome.reduce(FrequencyDistribution<Int>.additiveIdentity) {
             let (outcome, frequency) = $1
             let addend = y.power(outcome).normalizeFrequencies().scaleFrequencies(frequency)
             return $0.add(addend)

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -82,7 +82,7 @@ extension MultiplicationExpression_Tests {
         
         var evaluateCalled = 0
         var stubResulter: () -> Result = { 0 }
-        var stubProbabilityMass = ProbabilityMass(0)
+        var stubProbabilityMass = ExpressionProbabilityMass(0)
         
         func evaluate() -> Result {
             let result = stubResulter()
@@ -90,7 +90,7 @@ extension MultiplicationExpression_Tests {
             return result
         }
         
-        var probabilityMass: ProbabilityMass {
+        var probabilityMass: ExpressionProbabilityMass {
             return stubProbabilityMass
         }
         

--- a/DiceKitTests/ProbabilisticExpressionType_Tests.swift
+++ b/DiceKitTests/ProbabilisticExpressionType_Tests.swift
@@ -21,13 +21,13 @@ extension ProbabilisticExpressionType_Tests {
     
     struct MockProbabilisticExpression: ProbabilisticExpressionType {
         
-        var probabilityMass: ProbabilityMass
+        var probabilityMass: ExpressionProbabilityMass
         
     }
     
     func test_equivalent_shouldUseApproximatelyEqualForProbabilityMass() {
         let probability = 0.5
-        let delta = ProbabilityMass.defaultProbabilityEqualityDelta
+        let delta = ProbabilityMassConfig.defaultProbabilityEqualityDelta
         let insideDeltaProbability = probability + delta/10
         let outsideDeltaProbability = probability + delta
         let x = MockProbabilisticExpression(probabilityMass: ProbabilityMass(FrequencyDistribution([1: probability, 2: 1.0-probability])))

--- a/DiceKitTests/ProbabilityMass_Tests.swift
+++ b/DiceKitTests/ProbabilityMass_Tests.swift
@@ -15,6 +15,8 @@ import DiceKit
 /// Tests the `ProbabilityMass` type
 class ProbabilityMass_Tests: XCTestCase {
     
+    typealias SwiftCheckFrequencyDistribution = FrequencyDistributionOf<Int>
+    
     let operationFixture1 = ProbabilityMass(FrequencyDistribution([1: 2.0, 4: 3.0, 11: 1.0]))
     let operationFixture2 = ProbabilityMass(FrequencyDistribution([1: 1.5, 2: 7.0]))
 
@@ -25,7 +27,9 @@ extension ProbabilityMass_Tests {
     
     func test_init_shouldNormalizeFrequencyDistribution() {
         property("init with frequency distribution") <- forAll {
-            (a: FrequencyDistribution) in
+            (a: SwiftCheckFrequencyDistribution) in
+            
+            let a = a.getFrequencyDistribution
             
             let expectedFreqDist = a.normalizeFrequencies()
             
@@ -54,7 +58,9 @@ extension ProbabilityMass_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (a: FrequencyDistribution) in
+            (a: SwiftCheckFrequencyDistribution) in
+            
+            let a = a.getFrequencyDistribution
             
             return EquatableTestUtilities.checkReflexive { ProbabilityMass(a) }
         }
@@ -62,7 +68,9 @@ extension ProbabilityMass_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (a: FrequencyDistribution) in
+            (a: SwiftCheckFrequencyDistribution) in
+            
+            let a = a.getFrequencyDistribution
             
             return EquatableTestUtilities.checkSymmetric { ProbabilityMass(a) }
         }
@@ -70,7 +78,9 @@ extension ProbabilityMass_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (a: FrequencyDistribution) in
+            (a: SwiftCheckFrequencyDistribution) in
+            
+            let a = a.getFrequencyDistribution
             
             return EquatableTestUtilities.checkTransitive { ProbabilityMass(a) }
         }
@@ -78,9 +88,12 @@ extension ProbabilityMass_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: FrequencyDistribution, b: FrequencyDistribution) in
+            (a: SwiftCheckFrequencyDistribution, b: SwiftCheckFrequencyDistribution) in
             
-            return !(a.normalizeFrequencies().approximatelyEqual(b.normalizeFrequencies(), delta: ProbabilityMass.defaultProbabilityEqualityDelta) ) ==> {
+            let a = a.getFrequencyDistribution
+            let b = b.getFrequencyDistribution
+            
+            return !(a.normalizeFrequencies().approximatelyEqual(b.normalizeFrequencies(), delta: ProbabilityMassConfig.defaultProbabilityEqualityDelta) ) ==> {
                 return EquatableTestUtilities.checkNotEquate(
                     { ProbabilityMass(a) },
                     { ProbabilityMass(b) }
@@ -98,10 +111,10 @@ extension ProbabilityMass_Tests {
     func test_indexable_forIn() {
         // TODO: SwiftCheck
         let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1, 2:1, 3:4, 6:1]
-        let expectedElements: [ProbabilityMass._Element] = [(1, 1/7), (2, 1/7), (3, 4/7), (6, 1/7)]
+        let expectedElements: [ProbabilityMass<Int>._Element] = [(1, 1/7), (2, 1/7), (3, 4/7), (6, 1/7)]
         let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
         
-        var elements: [ProbabilityMass._Element] = []
+        var elements: [ProbabilityMass<Int>._Element] = []
         for element in probMass {
             elements.append(element)
         }
@@ -141,7 +154,7 @@ extension ProbabilityMass_Tests {
 extension ProbabilityMass_Tests {
     
     func test_approximatelyEqualOperator_shouldUseDelta() {
-        let delta = ProbabilityMass.defaultProbabilityEqualityDelta
+        let delta = ProbabilityMassConfig.defaultProbabilityEqualityDelta
         let probability = 0.5
         let insideDeltaProbability = probability + delta/10
         let outsideDeltaProbability = probability + delta


### PR DESCRIPTION
This allows future probability distributions that hold more information in the `Outcome` type.

Needed to support #4.
