### PR TITLE
Tests cleanup

### DIFF
--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		531084C01B5AF993008DD696 /* MultiplicationExpressionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */; };
 		531084C31B5B0761008DD696 /* Die.Roll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084C11B5B0102008DD696 /* Die.Roll.swift */; };
+		531E4F5F1B73F5E20073F01A /* EquatableTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */; };
 		533D0C771B6419F8003A7D32 /* FrequencyDistribution_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */; };
 		533D0C7B1B6423FA003A7D32 /* ProbabilityMass_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */; };
 		533D0C7D1B643F6C003A7D32 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C7C1B643F6C003A7D32 /* Constant.swift */; };
@@ -75,6 +76,7 @@
 		531084BD1B5AF859008DD696 /* ExpressionResultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpressionResultType.swift; sourceTree = "<group>"; };
 		531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiplicationExpressionResult.swift; sourceTree = "<group>"; };
 		531084C11B5B0102008DD696 /* Die.Roll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.Roll.swift; sourceTree = "<group>"; };
+		531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EquatableTestUtilities.swift; sourceTree = "<group>"; };
 		533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistribution_Tests.swift; sourceTree = "<group>"; };
 		533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilityMass_Tests.swift; sourceTree = "<group>"; };
 		533D0C7C1B643F6C003A7D32 /* Constant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				539D56891B5B6D6A00AC6A37 /* AdditionExpressionResult_Tests.swift */,
 				533F880D1B52B988003838C8 /* Die_Tests.swift */,
 				53D1EC7F1B63DF0C00433D2C /* Dictionary+Functions_Tests.swift */,
+				531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */,
 				533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */,
 				539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */,
 				53D05EEB1B546C73007CE7FC /* Int+Random_Tests.swift */,
@@ -397,6 +400,7 @@
 				539D56861B5B6D2B00AC6A37 /* NegationExpressionResult_Tests.swift in Sources */,
 				539D56881B5B6D4A00AC6A37 /* AdditionExpression_Tests.swift in Sources */,
 				539EAC671B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift in Sources */,
+				531E4F5F1B73F5E20073F01A /* EquatableTestUtilities.swift in Sources */,
 				533D0C7B1B6423FA003A7D32 /* ProbabilityMass_Tests.swift in Sources */,
 				53D1EC801B63DF0C00433D2C /* Dictionary+Functions_Tests.swift in Sources */,
 			);

--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		531084C01B5AF993008DD696 /* MultiplicationExpressionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */; };
 		531084C31B5B0761008DD696 /* Die.Roll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084C11B5B0102008DD696 /* Die.Roll.swift */; };
 		531E4F5F1B73F5E20073F01A /* EquatableTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */; };
+		531E4F611B7400270073F01A /* Arbitrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F601B7400270073F01A /* Arbitrary.swift */; };
 		533D0C771B6419F8003A7D32 /* FrequencyDistribution_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */; };
 		533D0C7B1B6423FA003A7D32 /* ProbabilityMass_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */; };
 		533D0C7D1B643F6C003A7D32 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C7C1B643F6C003A7D32 /* Constant.swift */; };
@@ -77,6 +78,7 @@
 		531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiplicationExpressionResult.swift; sourceTree = "<group>"; };
 		531084C11B5B0102008DD696 /* Die.Roll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.Roll.swift; sourceTree = "<group>"; };
 		531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EquatableTestUtilities.swift; sourceTree = "<group>"; };
+		531E4F601B7400270073F01A /* Arbitrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arbitrary.swift; sourceTree = "<group>"; };
 		533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistribution_Tests.swift; sourceTree = "<group>"; };
 		533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilityMass_Tests.swift; sourceTree = "<group>"; };
 		533D0C7C1B643F6C003A7D32 /* Constant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				53D05ECF1B532208007CE7FC /* Supporting Files */,
 				539D56871B5B6D4A00AC6A37 /* AdditionExpression_Tests.swift */,
 				539D56891B5B6D6A00AC6A37 /* AdditionExpressionResult_Tests.swift */,
+				531E4F601B7400270073F01A /* Arbitrary.swift */,
 				533F880D1B52B988003838C8 /* Die_Tests.swift */,
 				53D1EC7F1B63DF0C00433D2C /* Dictionary+Functions_Tests.swift */,
 				531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */,
@@ -391,6 +394,7 @@
 			files = (
 				539D56841B5B6D1A00AC6A37 /* NegationExpression_Tests.swift in Sources */,
 				53FA0EAE1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift in Sources */,
+				531E4F611B7400270073F01A /* Arbitrary.swift in Sources */,
 				533EB1EE1B5B293000B3F8A1 /* MultiplicationExpressionResult_Tests.swift in Sources */,
 				53CFC3111B5AE4A0009C6C8F /* MultiplicationExpression_Tests.swift in Sources */,
 				53D05EEC1B546C73007CE7FC /* Int+Random_Tests.swift in Sources */,

--- a/DiceKit/FrequencyDistribution.swift
+++ b/DiceKit/FrequencyDistribution.swift
@@ -135,7 +135,10 @@ extension FrequencyDistribution {
         }
         
         for (outcome, frequency) in frequenciesPerOutcome {
-            let otherFrequency = x.frequenciesPerOutcome[outcome]!
+            guard let otherFrequency = x.frequenciesPerOutcome[outcome] else {
+                return false
+            }
+            
             let diff = abs(frequency - otherFrequency)
             if diff > delta {
                 return false

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -27,9 +27,7 @@ extension AdditionExpressionResult_Tests {
             let a = c(Int(a))
             let b = c(Int(b))
             
-            let x = AdditionExpressionResult(a, b)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive { AdditionExpressionResult(a, b) }
         }
     }
     
@@ -40,10 +38,7 @@ extension AdditionExpressionResult_Tests {
             let a = c(Int(a))
             let b = c(Int(b))
             
-            let x = AdditionExpressionResult(a, b)
-            let y = AdditionExpressionResult(a, b)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric { AdditionExpressionResult(a, b) }
         }
     }
     
@@ -54,11 +49,7 @@ extension AdditionExpressionResult_Tests {
             let a = c(Int(a))
             let b = c(Int(b))
             
-            let x = AdditionExpressionResult(a, b)
-            let y = AdditionExpressionResult(a, b)
-            let z = AdditionExpressionResult(a, b)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive { AdditionExpressionResult(a, b) }
         }
     }
     
@@ -73,10 +64,10 @@ extension AdditionExpressionResult_Tests {
             let m = c(Int(m))
             let n = c(Int(n))
             
-            let x = AdditionExpressionResult(a, b)
-            let y = AdditionExpressionResult(m, n)
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { AdditionExpressionResult(a, b) },
+                { AdditionExpressionResult(m, n) }
+            )
         }
     }
     

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -22,10 +22,7 @@ extension AdditionExpressionResult_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (a: Int16, b: Int16) in
-            
-            let a = c(Int(a))
-            let b = c(Int(b))
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkReflexive { AdditionExpressionResult(a, b) }
         }
@@ -33,10 +30,7 @@ extension AdditionExpressionResult_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (a: Int16, b: Int16) in
-            
-            let a = c(Int(a))
-            let b = c(Int(b))
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkSymmetric { AdditionExpressionResult(a, b) }
         }
@@ -44,10 +38,7 @@ extension AdditionExpressionResult_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (a: Int16, b: Int16) in
-            
-            let a = c(Int(a))
-            let b = c(Int(b))
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkTransitive { AdditionExpressionResult(a, b) }
         }
@@ -55,14 +46,9 @@ extension AdditionExpressionResult_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: Int16, b: Int16, m: Int16, n: Int16) in
+            (a: Constant, b: Constant, m: Constant, n: Constant) in
             
             guard !(a == m && b == n) && !(a == n && b == m) else { return true }
-            
-            let a = c(Int(a))
-            let b = c(Int(b))
-            let m = c(Int(m))
-            let n = c(Int(n))
             
             return EquatableTestUtilities.checkNotEquate(
                 { AdditionExpressionResult(a, b) },

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -48,12 +48,12 @@ extension AdditionExpressionResult_Tests {
         property("non-equal") <- forAll {
             (a: Constant, b: Constant, m: Constant, n: Constant) in
             
-            guard !(a == m && b == n) && !(a == n && b == m) else { return true }
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { AdditionExpressionResult(a, b) },
-                { AdditionExpressionResult(m, n) }
-            )
+            return (!(a == m && b == n) && !(a == n && b == m)) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { AdditionExpressionResult(a, b) },
+                    { AdditionExpressionResult(m, n) }
+                )
+            }
         }
     }
     

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -49,12 +49,12 @@ extension AdditionExpression_Tests {
             (a: Constant, b: Constant, m: Constant, n: Constant) in
             
             // Check both cases since it's commutative
-            guard !(a == m && b == n || a == n && b == m) else { return true }
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { AdditionExpression(a, b) },
-                { AdditionExpression(m, n) }
-            )
+            return !(a == m && b == n || a == n && b == m) ==> {
+                return EquatableTestUtilities.checkNotEquate(
+                    { AdditionExpression(a, b) },
+                    { AdditionExpression(m, n) }
+                )
+            }
         }
     }
     
@@ -62,12 +62,12 @@ extension AdditionExpression_Tests {
         property("commutative") <- forAll {
             (a: Constant, b: Constant) in
             
-            guard a != b else { return true }
-            
-            let x = AdditionExpression(a, b)
-            let y = AdditionExpression(b, a)
-            
-            return x == y
+            return (a != b) ==> {
+                let x = AdditionExpression(a, b)
+                let y = AdditionExpression(b, a)
+                
+                return x == y
+            }
         }
     }
     

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -27,9 +27,7 @@ extension AdditionExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = AdditionExpression(a, b)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive { AdditionExpression(a, b) }
         }
     }
     
@@ -40,10 +38,7 @@ extension AdditionExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = AdditionExpression(a, b)
-            let y = AdditionExpression(a, b)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric { AdditionExpression(a, b) }
         }
     }
     
@@ -54,11 +49,7 @@ extension AdditionExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = AdditionExpression(a, b)
-            let y = AdditionExpression(a, b)
-            let z = AdditionExpression(a, b)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive { AdditionExpression(a, b) }
         }
     }
     
@@ -74,10 +65,10 @@ extension AdditionExpression_Tests {
             let m = c(m)
             let n = c(n)
             
-            let x = AdditionExpression(a, b)
-            let y = AdditionExpression(m, n)
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { AdditionExpression(a, b) },
+                { AdditionExpression(m, n) }
+            )
         }
     }
     

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -22,10 +22,7 @@ extension AdditionExpression_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkReflexive { AdditionExpression(a, b) }
         }
@@ -33,10 +30,7 @@ extension AdditionExpression_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkSymmetric { AdditionExpression(a, b) }
         }
@@ -44,10 +38,7 @@ extension AdditionExpression_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkTransitive { AdditionExpression(a, b) }
         }
@@ -55,15 +46,10 @@ extension AdditionExpression_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: Int, b: Int, m: Int, n: Int) in
+            (a: Constant, b: Constant, m: Constant, n: Constant) in
             
             // Check both cases since it's commutative
             guard !(a == m && b == n || a == n && b == m) else { return true }
-            
-            let a = c(a)
-            let b = c(b)
-            let m = c(m)
-            let n = c(n)
             
             return EquatableTestUtilities.checkNotEquate(
                 { AdditionExpression(a, b) },
@@ -74,12 +60,9 @@ extension AdditionExpression_Tests {
     
     func test_shouldBeCommutative() {
         property("commutative") <- forAll {
-            (a: Int, b: Int) in
+            (a: Constant, b: Constant) in
             
             guard a != b else { return true }
-            
-            let a = c(a)
-            let b = c(b)
             
             let x = AdditionExpression(a, b)
             let y = AdditionExpression(b, a)
@@ -95,10 +78,7 @@ extension AdditionExpression_Tests {
     
     func test_evaluate_shouldCreateResultCorrectly() {
         property("create results") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             let expression = AdditionExpression(a, b)
             
@@ -110,10 +90,7 @@ extension AdditionExpression_Tests {
     
     func test_probabilityMass_shouldReturnCorrect() {
         property("probability mass") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             let expectedProbMass = a.probabilityMass.and(b.probabilityMass)
             let expression = AdditionExpression(a, b)

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -1,0 +1,21 @@
+//
+//  Arbitrary.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/6/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import SwiftCheck
+import DiceKit
+
+extension Constant: Arbitrary {
+    
+    public static func create(x : Int) -> Constant {
+        return Constant(x)
+    }
+    
+    public static var arbitrary : Gen<Constant> {
+        return Constant.create <^> Int.arbitrary
+    }
+}

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -19,3 +19,14 @@ extension Constant: Arbitrary {
         return Constant.create <^> Int.arbitrary
     }
 }
+
+extension Die: Arbitrary {
+    
+    public static func create(x : Int) -> Die {
+        return Die(sides: x)
+    }
+    
+    public static var arbitrary : Gen<Die> {
+        return Die.create <^> Int.arbitrary
+    }
+}

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -30,3 +30,15 @@ extension Die: Arbitrary {
         return Die.create <^> Int.arbitrary
     }
 }
+
+extension FrequencyDistribution: Arbitrary {
+    
+    public static func create(x : FrequenciesPerOutcome) -> FrequencyDistribution {
+        return FrequencyDistribution(x)
+    }
+    
+    public static var arbitrary : Gen<FrequencyDistribution> {
+        return FrequencyDistribution.create <^> Dictionary<Outcome, Frequency>.arbitrary
+    }
+    
+}

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -9,6 +9,15 @@
 import SwiftCheck
 import DiceKit
 
+public extension CollectionType where Index.Distance: protocol<Arbitrary, IntegerType> {
+    
+    /// Generates an arbitrary index within 0..<count
+    public var arbitraryIndex : Gen<Index.Distance> {
+        return Index.Distance.arbitrary.resize(Int(self.count.toIntMax())).suchThat { $0 >= 0 }
+    }
+    
+}
+
 extension Constant: Arbitrary {
     
     public static func create(x : Int) -> Constant {

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -138,9 +138,7 @@ extension Die_Tests {
             
             let sides = Int(i)
             
-            let x = Die(sides: sides)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive { Die(sides: sides) }
         }
     }
     
@@ -150,10 +148,7 @@ extension Die_Tests {
             
             let sides = Int(i)
             
-            let x = Die(sides: sides)
-            let y = Die(sides: sides)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric { Die(sides: sides) }
         }
     }
     
@@ -163,11 +158,7 @@ extension Die_Tests {
             
             let sides = Int(i)
             
-            let x = Die(sides: sides)
-            let y = Die(sides: sides)
-            let z = Die(sides: sides)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive { Die(sides: sides) }
         }
     }
     
@@ -177,10 +168,10 @@ extension Die_Tests {
             
             guard a != b else { return true }
             
-            let x = Die(sides: Int(a))
-            let y = Die(sides: Int(b))
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { Die(sides: Int(a)) },
+                { Die(sides: Int(b)) }
+            )
         }
     }
     

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -273,9 +273,12 @@ extension Die_Tests {
         property("generates values within range of -sides...sides") <- forAll {
             (i: Int) in
             
-            let result = rollerType(sides: i)
-            
-            return (-i...i).contains(result)
+            // Int.min has one more value than Int.max, making this crash when negating it
+            return (i >= 0) ==> {
+                let result = rollerType(sides: i)
+                
+                return (-i...i).contains(result)
+            }
         }
     }
     
@@ -369,7 +372,7 @@ extension Die_Tests {
     
     // MARK: - signedOpenRoller
     func test_RollerType_signedOpenRoller_shouldReturnWithinOpenRangeForSides() {
-        common_RollerType_shouldReturnWithinPositiveRangeForSidesGreaterThan1(Die.signedClosedRoller)
+        common_RollerType_shouldReturnWithinRangeForSides(Die.signedOpenRoller)
     }
     
     func test_RollerType_signedOpenRoller_shouldWorkForManySides() {

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -15,12 +15,6 @@ import DiceKit
 /// Tests the `Die` type
 class Die_Tests: XCTestCase {
     
-    #if arch(i386) || arch(arm) // 32-bit
-        typealias PositiveSidesType = UInt16
-    #else // 64-bit
-        typealias PositiveSidesType = UInt32
-    #endif
-    
     override func setUp() {
         Die.roller = Die.defaultRoller
     }
@@ -134,44 +128,38 @@ extension Die_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            let sides = Int(i)
-            
-            return EquatableTestUtilities.checkReflexive { Die(sides: sides) }
+            return EquatableTestUtilities.checkReflexive { Die(sides: i) }
         }
     }
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            let sides = Int(i)
-            
-            return EquatableTestUtilities.checkSymmetric { Die(sides: sides) }
+            return EquatableTestUtilities.checkSymmetric { Die(sides: i) }
         }
     }
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            let sides = Int(i)
-            
-            return EquatableTestUtilities.checkTransitive { Die(sides: sides) }
+            return EquatableTestUtilities.checkTransitive { Die(sides: i) }
         }
     }
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: PositiveSidesType, b: PositiveSidesType) in
+            (a: Int, b: Int) in
             
-            guard a != b else { return true }
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { Die(sides: Int(a)) },
-                { Die(sides: Int(b)) }
-            )
+            return (a != b) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { Die(sides: a) },
+                    { Die(sides: b) }
+                )
+            }
         }
     }
     
@@ -259,55 +247,47 @@ extension Die_Tests {
     
     func common_RollerType_shouldReturnWithinPositiveRangeForSidesGreaterThan1(rollerType: Die.RollerType) {
         property("generates values within range of 1...sides") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            guard i > 1 else { return true }
-            
-            let sides = Int(i)
-            
-            let result = rollerType(sides: sides)
-            
-            return result > 0 && result <= sides
+            return (i > 1) ==> {
+                let result = rollerType(sides: i)
+                
+                return result > 0 && result <= i
+            }
         }
     }
     
     func common_RollerType_shouldReturnWithinNegativeRangeForSidesLessThan0(rollerType: Die.RollerType) {
         property("generates values within range of sides..<0") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            guard i > 1 else { return true }
-            
-            let sides = -Int(i)
-            
-            let result = rollerType(sides: sides)
-            
-            return result < 0 && result >= sides
+            return (i < -1) ==> {
+                let result = rollerType(sides: i)
+                
+                return result < 0 && result >= i
+            }
         }
     }
     
     func common_RollerType_shouldReturnWithinRangeForSides(rollerType: Die.RollerType) {
         property("generates values within range of -sides...sides") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            let sides = Int(i)
+            let result = rollerType(sides: i)
             
-            let result = rollerType(sides: sides)
-            
-            return (-sides...sides).contains(result)
+            return (-i...i).contains(result)
         }
     }
     
     func common_RollerType_shouldReturn0ForSidesLessThan0(rollerType: Die.RollerType) {
         property("generates 0 for -sides") <- forAll {
-            (i: PositiveSidesType) in
+            (i: Int) in
             
-            guard i > 0 else { return true }
-            
-            let sides = -Int(i)
-            
-            let result = rollerType(sides: sides)
-            
-            return result == 0
+            return (i < 0) ==> {
+                let result = rollerType(sides: i)
+                
+                return result == 0
+            }
         }
     }
     

--- a/DiceKitTests/EquatableTestUtilities.swift
+++ b/DiceKitTests/EquatableTestUtilities.swift
@@ -1,0 +1,41 @@
+//
+//  EquatableTestUtilities.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/6/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+// enum simply for scoping
+enum EquatableTestUtilities {
+    
+    static func checkReflexive<T: Equatable>(initializedType: () -> T) -> Bool {
+        let x = initializedType()
+            
+        return x == x
+    }
+    
+    static func checkSymmetric<T: Equatable>(initializedType: () -> T) -> Bool {
+        let x = initializedType()
+        let y = initializedType()
+        
+        return x == y && y == x
+    }
+    
+    static func checkTransitive<T: Equatable>(initializedType: () -> T) -> Bool {
+        let x = initializedType()
+        let y = initializedType()
+        let z = initializedType()
+        
+        return x == y && y == z && x == z
+    }
+    
+    static func checkNotEquate<T: Equatable>(initializedType: () -> T, _ differentNotEqualInitializedType: () -> T) -> Bool {
+        let x = initializedType()
+        let y = differentNotEqualInitializedType()
+        
+        return x != y
+    }
+
+    
+}

--- a/DiceKitTests/FrequencyDistributionIndex_Tests.swift
+++ b/DiceKitTests/FrequencyDistributionIndex_Tests.swift
@@ -45,7 +45,65 @@ extension FrequencyDistributionIndex_Tests {
 // MARK: - Equatable
 extension FrequencyDistributionIndex_Tests {
     
-    // TODO: Equatable
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (a: SwiftCheckOrderedOutcome) in
+            
+            let a = a.getSet
+            
+            let index = Int(arc4random_uniform(UInt32(a.count)))
+            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            
+            return EquatableTestUtilities.checkReflexive { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (a: SwiftCheckOrderedOutcome) in
+            
+            let a = a.getSet
+            
+            let index = Int(arc4random_uniform(UInt32(a.count)))
+            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            
+            return EquatableTestUtilities.checkSymmetric { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (a: SwiftCheckOrderedOutcome) in
+            
+            let a = a.getSet
+            
+            let index = Int(arc4random_uniform(UInt32(a.count)))
+            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            
+            return EquatableTestUtilities.checkTransitive { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: SwiftCheckOrderedOutcome, b: SwiftCheckOrderedOutcome) in
+            
+            let a = a.getSet
+            let b = b.getSet
+            
+            return (a != b) ==> {
+                let aIndex = Int(arc4random_uniform(UInt32(a.count)))
+                let aOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                let bIndex = Int(arc4random_uniform(UInt32(b.count)))
+                let bOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(b)
+                
+                return EquatableTestUtilities.checkNotEquate(
+                    { FrequencyDistributionIndex(index: aIndex, orderedOutcomes: aOrderedOutcomes) },
+                    { FrequencyDistributionIndex(index: bIndex, orderedOutcomes: bOrderedOutcomes) }
+                )
+            }
+        }
+    }
     
 }
 

--- a/DiceKitTests/FrequencyDistributionIndex_Tests.swift
+++ b/DiceKitTests/FrequencyDistributionIndex_Tests.swift
@@ -28,15 +28,19 @@ extension FrequencyDistributionIndex_Tests {
             
             let a = a.getSet
             
-            let expectedIndex = Int(arc4random_uniform(UInt32(a.count)))
-            let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
-            
-            let freqDistIndex = FrequencyDistributionIndex(index: expectedIndex, orderedOutcomes: expectedOrderedOutcomes)
-            
-            let testIndex = freqDistIndex.index == expectedIndex
-            let testOrderedOutcomes = freqDistIndex.orderedOutcomes == expectedOrderedOutcomes
-            
-            return testIndex && testOrderedOutcomes
+            return forAll(a.arbitraryIndex) {
+                (index) in
+                
+                let expectedIndex = index
+                let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                
+                let freqDistIndex = FrequencyDistributionIndex(index: expectedIndex, orderedOutcomes: expectedOrderedOutcomes)
+                
+                let testIndex = freqDistIndex.index == expectedIndex
+                let testOrderedOutcomes = freqDistIndex.orderedOutcomes == expectedOrderedOutcomes
+                
+                return testIndex && testOrderedOutcomes
+            }
         }
     }
     
@@ -51,10 +55,13 @@ extension FrequencyDistributionIndex_Tests {
             
             let a = a.getSet
             
-            let index = Int(arc4random_uniform(UInt32(a.count)))
-            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
-            
-            return EquatableTestUtilities.checkReflexive { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+            return forAll(a.arbitraryIndex) {
+                (index) in
+                
+                let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                
+                return EquatableTestUtilities.checkReflexive { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+            }
         }
     }
     
@@ -64,10 +71,13 @@ extension FrequencyDistributionIndex_Tests {
             
             let a = a.getSet
             
-            let index = Int(arc4random_uniform(UInt32(a.count)))
-            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
-            
-            return EquatableTestUtilities.checkSymmetric { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+            return forAll(a.arbitraryIndex) {
+                (index) in
+                
+                let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                
+                return EquatableTestUtilities.checkSymmetric { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+            }
         }
     }
     
@@ -77,10 +87,13 @@ extension FrequencyDistributionIndex_Tests {
             
             let a = a.getSet
             
-            let index = Int(arc4random_uniform(UInt32(a.count)))
-            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
-            
-            return EquatableTestUtilities.checkTransitive { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+            return forAll(a.arbitraryIndex) {
+                (index) in
+                
+                let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                
+                return EquatableTestUtilities.checkTransitive { FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes) }
+            }
         }
     }
     
@@ -92,15 +105,19 @@ extension FrequencyDistributionIndex_Tests {
             let b = b.getSet
             
             return (a != b) ==> {
-                let aIndex = Int(arc4random_uniform(UInt32(a.count)))
-                let aOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
-                let bIndex = Int(arc4random_uniform(UInt32(b.count)))
-                let bOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(b)
+                // I know, it's ugly. The only way I could get it to compile though.
+                // Hopefully we can cleqan it up someday.
+                forAll(a.arbitraryIndex) { (aIndex) in forAll(b.arbitraryIndex) {
+                    (bIndex) in
                 
-                return EquatableTestUtilities.checkNotEquate(
-                    { FrequencyDistributionIndex(index: aIndex, orderedOutcomes: aOrderedOutcomes) },
-                    { FrequencyDistributionIndex(index: bIndex, orderedOutcomes: bOrderedOutcomes) }
-                )
+                    let aOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                    let bOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(b)
+                    
+                    return EquatableTestUtilities.checkNotEquate(
+                        { FrequencyDistributionIndex(index: aIndex, orderedOutcomes: aOrderedOutcomes) },
+                        { FrequencyDistributionIndex(index: bIndex, orderedOutcomes: bOrderedOutcomes) }
+                    )
+                }}
             }
         }
     }
@@ -153,14 +170,17 @@ extension FrequencyDistributionIndex_Tests {
             let a = a.getSet
             
             return (a.count > 0) ==> {
-                let index = Int(arc4random_uniform(UInt32(a.count)))
-                let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
-                let freqDistIndex = FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes)
-                let expectedValue = orderedOutcomes[index]
+                return forAll(a.arbitraryIndex) {
+                    (index) in
                 
-                let value = freqDistIndex.value
-                
-                return value == expectedValue
+                    let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                    let freqDistIndex = FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes)
+                    let expectedValue = orderedOutcomes[index]
+                    
+                    let value = freqDistIndex.value
+                    
+                    return value == expectedValue
+                }
             }
         }
     }

--- a/DiceKitTests/FrequencyDistributionIndex_Tests.swift
+++ b/DiceKitTests/FrequencyDistributionIndex_Tests.swift
@@ -8,11 +8,14 @@
 
 import XCTest
 import Nimble
+import SwiftCheck
 
 @testable import DiceKit
 
 /// Tests the `FrequencyDistributionIndex` type
 class FrequencyDistributionIndex_Tests: XCTestCase {
+    
+    typealias SwiftCheckOrderedOutcome = SetOf<FrequencyDistribution.Outcome>
     
 }
 
@@ -20,14 +23,21 @@ class FrequencyDistributionIndex_Tests: XCTestCase {
 extension FrequencyDistributionIndex_Tests {
     
     func test_init_shouldSucceed() {
-        // TODO: SwiftCheck
-        let expectedIndex = 3
-        let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes([3, 6, 8, 9, 11, 12, 45])
-        
-        let freqDistIndex = FrequencyDistributionIndex(index: expectedIndex, orderedOutcomes: expectedOrderedOutcomes)
-        
-        expect(freqDistIndex.index) == expectedIndex
-        expect(freqDistIndex.orderedOutcomes) == expectedOrderedOutcomes
+        property("init") <- forAll {
+            (a: SwiftCheckOrderedOutcome) in
+            
+            let a = a.getSet
+            
+            let expectedIndex = Int(arc4random_uniform(UInt32(a.count)))
+            let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            
+            let freqDistIndex = FrequencyDistributionIndex(index: expectedIndex, orderedOutcomes: expectedOrderedOutcomes)
+            
+            let testIndex = freqDistIndex.index == expectedIndex
+            let testOrderedOutcomes = freqDistIndex.orderedOutcomes == expectedOrderedOutcomes
+            
+            return testIndex && testOrderedOutcomes
+        }
     }
     
 }
@@ -43,48 +53,74 @@ extension FrequencyDistributionIndex_Tests {
 extension FrequencyDistributionIndex_Tests {
     
     func test_startIndex_shouldBeSetupCorrectly() {
-        // TODO: SwiftCheck
-        let expectedIndex = 0
-        let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes([4, 6, 8, 10, 11, 12, 33, 43])
-        
-        let startIndex = FrequencyDistributionIndex.startIndex(expectedOrderedOutcomes)
-        
-        expect(startIndex.index) == expectedIndex
-        expect(startIndex.orderedOutcomes) == expectedOrderedOutcomes
+        property("startIndex") <- forAll {
+            (a: SetOf<FrequencyDistribution.Outcome>) in
+            
+            let a = a.getSet
+            
+            let expectedIndex = 0
+            let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            
+            let startIndex = FrequencyDistributionIndex.startIndex(expectedOrderedOutcomes)
+            
+            let testIndex = startIndex.index == expectedIndex
+            let testOrderedOutcomes = startIndex.orderedOutcomes == expectedOrderedOutcomes
+            
+            return testIndex && testOrderedOutcomes
+        }
     }
     
     func test_endIndex_shouldBeSetupCorrectly() {
-        // TODO: SwiftCheck
-        let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes([4, 6, 8, 10, 11, 14, 34])
-        let expectedIndex = expectedOrderedOutcomes.count
+        property("endIndex") <- forAll {
+            (a: SetOf<FrequencyDistribution.Outcome>) in
+            
+            let a = a.getSet
+            
+            let expectedOrderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            let expectedIndex = expectedOrderedOutcomes.count
         
-        let endIndex = FrequencyDistributionIndex.endIndex(expectedOrderedOutcomes)
-        
-        expect(endIndex.index) == expectedIndex
-        expect(endIndex.orderedOutcomes) == expectedOrderedOutcomes
+            let endIndex = FrequencyDistributionIndex.endIndex(expectedOrderedOutcomes)
+            
+            let testIndex = endIndex.index == expectedIndex
+            let testOrderedOutcomes = endIndex.orderedOutcomes == expectedOrderedOutcomes
+            
+            return testIndex && testOrderedOutcomes
+        }
     }
     
     func test_value_shouldReturnValueForValidIndex() {
-        // TODO: SwiftCheck
-        let index = 2
-        let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes([3, 6, 8, 9, 11, 12, 45])
-        let freqDistIndex = FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes)
-        let expectedValue = orderedOutcomes[index]
-        
-        let value = freqDistIndex.value
-        
-        expect(value) == expectedValue
+        property("value with valid index") <- forAll {
+            (a: SetOf<FrequencyDistribution.Outcome>) in
+            
+            let a = a.getSet
+            
+            return (a.count > 0) ==> {
+                let index = Int(arc4random_uniform(UInt32(a.count)))
+                let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+                let freqDistIndex = FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes)
+                let expectedValue = orderedOutcomes[index]
+                
+                let value = freqDistIndex.value
+                
+                return value == expectedValue
+            }
+        }
     }
     
     func test_value_shouldReturnNilForInvalidIndex() {
-        // TODO: SwiftCheck
-        let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes([3, 6, 8, 9, 11, 12, 45])
-        let index = orderedOutcomes.count
-        let freqDistIndex = FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes)
+        property("value with invalid index") <- forAll {
+            (a: SetOf<FrequencyDistribution.Outcome>) in
+            
+            let a = a.getSet
+            
+            let orderedOutcomes = FrequencyDistributionIndex.OrderedOutcomes(a)
+            let index = orderedOutcomes.count
+            let freqDistIndex = FrequencyDistributionIndex(index: index, orderedOutcomes: orderedOutcomes)
+            
+            let value = freqDistIndex.value
         
-        let value = freqDistIndex.value
-        
-        expect(value).to(beNil())
+            return value == nil
+        }
     }
     
     func test_successor_shouldReturnValidIndexWhenMoreRemain() {

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -8,11 +8,14 @@
 
 import XCTest
 import Nimble
+import SwiftCheck
 
 import DiceKit
 
 /// Tests the `FrequencyDistribution` type
 class FrequencyDistribution_Tests: XCTestCase {
+    
+    typealias SwiftCheckFrequenciesPerOutcome = DictionaryOf<FrequencyDistribution.Outcome, FrequencyDistribution.Frequency>
 
 }
 
@@ -20,12 +23,15 @@ class FrequencyDistribution_Tests: XCTestCase {
 extension FrequencyDistribution_Tests {
     
     func test_init_shouldSucceedWithFrequenciesPerOutcome() {
-        // TODO: SwiftCheck
-        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1, 2:1, 3:4, 4:1]
-        
-        let freqDist = FrequencyDistribution(frequenciesPerOutcome)
-        
-        expect(freqDist.frequenciesPerOutcome) == frequenciesPerOutcome
+        property("init") <- forAll {
+            (a: SwiftCheckFrequenciesPerOutcome) in
+            
+            let a = a.getDictionary
+            
+            let freqDist = FrequencyDistribution(a)
+            
+            return freqDist.frequenciesPerOutcome == a
+        }
     }
     
 }

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -39,7 +39,51 @@ extension FrequencyDistribution_Tests {
 // MARK: - Equatable
 extension FrequencyDistribution_Tests {
     
-    // TODO: Equatable
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (a: SwiftCheckFrequenciesPerOutcome) in
+            
+            let a = a.getDictionary
+            
+            return EquatableTestUtilities.checkReflexive { FrequencyDistribution(a) }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (a: SwiftCheckFrequenciesPerOutcome) in
+            
+            let a = a.getDictionary
+            
+            return EquatableTestUtilities.checkSymmetric { FrequencyDistribution(a) }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (a: SwiftCheckFrequenciesPerOutcome) in
+            
+            let a = a.getDictionary
+            
+            return EquatableTestUtilities.checkTransitive { FrequencyDistribution(a) }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: SwiftCheckFrequenciesPerOutcome, b: SwiftCheckFrequenciesPerOutcome) in
+            
+            let a = a.getDictionary
+            let b = b.getDictionary
+            
+            return (a != b) ==> {
+                return EquatableTestUtilities.checkNotEquate(
+                    { FrequencyDistribution(a) },
+                    { FrequencyDistribution(b) }
+                )
+            }
+        }
+    }
     
 }
 

--- a/DiceKitTests/Int+Random_Tests.swift
+++ b/DiceKitTests/Int+Random_Tests.swift
@@ -32,13 +32,13 @@ class Int_Random_Tests: XCTestCase {
         property("random(lower:upper:) generates values for all valid inputs") <- forAll {
             (a: UInt64, b: UInt64) in
             
-            guard a != b else { return true }
-            
-            let lower = min(a, b)
-            let upper = max(a, b)
-            _ = UInt64.random(lower: lower, upper: upper)
-            
-            return true
+            return (a != b) ==> {
+                let lower = min(a, b)
+                let upper = max(a, b)
+                _ = UInt64.random(lower: lower, upper: upper)
+                
+                return true
+            }
         }
     }
     
@@ -50,13 +50,13 @@ class Int_Random_Tests: XCTestCase {
         property("random(lower:upper:) generates values for all valid inputs") <- forAll {
             (a: Int64, b: Int64) in
             
-            guard a != b else { return true }
-            
-            let lower = min(a, b)
-            let upper = max(a, b)
-            _ = Int64.random(lower: lower, upper: upper)
-            
-            return true
+            return (a != b) ==> {
+                let lower = min(a, b)
+                let upper = max(a, b)
+                _ = Int64.random(lower: lower, upper: upper)
+                
+                return true
+            }
         }
     }
     
@@ -68,13 +68,13 @@ class Int_Random_Tests: XCTestCase {
         property("random(lower:upper:) generates values for all valid inputs") <- forAll {
             (a: UInt32, b: UInt32) in
             
-            guard a != b else { return true }
-            
-            let lower = min(a, b)
-            let upper = max(a, b)
-            _ = UInt32.random(lower: lower, upper: upper)
-            
-            return true
+            return (a != b) ==> {
+                let lower = min(a, b)
+                let upper = max(a, b)
+                _ = UInt32.random(lower: lower, upper: upper)
+                
+                return true
+            }
         }
     }
     
@@ -86,13 +86,13 @@ class Int_Random_Tests: XCTestCase {
         property("random(lower:upper:) generates values for all valid inputs") <- forAll {
             (a: Int32, b: Int32) in
             
-            guard a != b else { return true }
-            
-            let lower = min(a, b)
-            let upper = max(a, b)
-            _ = Int32.random(lower: lower, upper: upper)
-            
-            return true
+            return (a != b) ==> {
+                let lower = min(a, b)
+                let upper = max(a, b)
+                _ = Int32.random(lower: lower, upper: upper)
+                
+                return true
+            }
         }
     }
     
@@ -104,13 +104,13 @@ class Int_Random_Tests: XCTestCase {
         property("random(lower:upper:) generates values for all valid inputs") <- forAll {
             (a: UInt, b: UInt) in
             
-            guard a != b else { return true }
-            
-            let lower = min(a, b)
-            let upper = max(a, b)
-            _ = UInt.random(lower: lower, upper: upper)
-            
-            return true
+            return (a != b) ==> {
+                let lower = min(a, b)
+                let upper = max(a, b)
+                _ = UInt.random(lower: lower, upper: upper)
+                
+                return true
+            }
         }
     }
     
@@ -122,13 +122,13 @@ class Int_Random_Tests: XCTestCase {
         property("random(lower:upper:) generates values for all valid inputs") <- forAll {
             (a: Int, b: Int) in
             
-            guard a != b else { return true }
-            
-            let lower = min(a, b)
-            let upper = max(a, b)
-            _ = Int.random(lower: lower, upper: upper)
-            
-            return true
+            return (a != b) ==> {
+                let lower = min(a, b)
+                let upper = max(a, b)
+                _ = Int.random(lower: lower, upper: upper)
+                
+                return true
+            }
         }
     }
     

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -34,9 +34,9 @@ extension MultiplicationExpressionResult_Tests {
             
             let fixture = self.equatableFixture(a, b)
             
-            let x = MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive {
+                MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
+            }
         }
     }
     
@@ -46,10 +46,9 @@ extension MultiplicationExpressionResult_Tests {
             
             let fixture = self.equatableFixture(a, b)
             
-            let x = MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
-            let y = MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric {
+                MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
+            }
         }
     }
     
@@ -59,11 +58,9 @@ extension MultiplicationExpressionResult_Tests {
             
             let fixture = self.equatableFixture(a, b)
             
-            let x = MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
-            let y = MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
-            let z = MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive {
+                MultiplicationExpressionResult(multiplierResult: fixture.multiplierResult, multiplicandResults: fixture.multiplicandResults)
+            }
         }
     }
     
@@ -76,10 +73,10 @@ extension MultiplicationExpressionResult_Tests {
             let xFixture = self.equatableFixture(a, b)
             let yFixture = self.equatableFixture(c, d)
             
-            let x = MultiplicationExpressionResult(multiplierResult: xFixture.multiplierResult, multiplicandResults: xFixture.multiplicandResults)
-            let y = MultiplicationExpressionResult(multiplierResult: yFixture.multiplierResult, multiplicandResults: yFixture.multiplicandResults)
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { MultiplicationExpressionResult(multiplierResult: xFixture.multiplierResult, multiplicandResults: xFixture.multiplicandResults) },
+                { MultiplicationExpressionResult(multiplierResult: yFixture.multiplierResult, multiplicandResults: yFixture.multiplicandResults) }
+            )
         }
     }
     

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -68,15 +68,16 @@ extension MultiplicationExpressionResult_Tests {
         property("non-equal") <- forAll {
             (a: UInt, b: UInt, c: UInt, d: UInt) in
             
-            guard a != c else { return true }
-            
-            let xFixture = self.equatableFixture(a, b)
-            let yFixture = self.equatableFixture(c, d)
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { MultiplicationExpressionResult(multiplierResult: xFixture.multiplierResult, multiplicandResults: xFixture.multiplicandResults) },
-                { MultiplicationExpressionResult(multiplierResult: yFixture.multiplierResult, multiplicandResults: yFixture.multiplicandResults) }
-            )
+            // Only check one set of parameters since not commutitive
+            return (a != c) ==> {
+                let xFixture = self.equatableFixture(a, b)
+                let yFixture = self.equatableFixture(c, d)
+                
+                return EquatableTestUtilities.checkNotEquate(
+                    { MultiplicationExpressionResult(multiplierResult: xFixture.multiplierResult, multiplicandResults: xFixture.multiplicandResults) },
+                    { MultiplicationExpressionResult(multiplierResult: yFixture.multiplierResult, multiplicandResults: yFixture.multiplicandResults) }
+                )
+            }
         }
     }
     

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -86,30 +86,38 @@ extension MultiplicationExpressionResult_Tests {
 // MARK: - ExpressionResultType
 extension MultiplicationExpressionResult_Tests {
     
-    // TODO: Make this a SwiftCheck test
     func test_value_shouldSumTheMultiplicandResultsForPositiveMultiplier() {
-        let multiplierResult = Int(arc4random_uniform(11)) // 0...10
-        let multiplicandCount = abs(multiplierResult)
-        let multiplicandResults = (0..<multiplicandCount).map { _ in c(Int(arc4random_uniform(100)) + 1) }
-        let expectedValue = multiplicandResults.reduce(0) { $0 + $1.value }
-        let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: multiplicandResults)
-        
-        let value = result.value
-        
-        expect(value) == expectedValue
+        property("value with positive multiplier") <- forAll {
+            (a: ArrayOf<Constant>) in
+            
+            let a = a.getArray
+            
+            let multiplierResult = a.count
+            let multiplicandResults = a
+            let expectedValue = multiplicandResults.reduce(0) { $0 + $1.value }
+            let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: multiplicandResults)
+            
+            let value = result.value
+            
+            return value == expectedValue
+        }
     }
     
-    // TODO: Make this a SwiftCheck test
     func test_value_shouldNegateTheMultiplicandResultsForNegativeMultiplier() {
-        let multiplierResult = -Int(arc4random_uniform(10)) - 1 // -1...10
-        let multiplicandCount = abs(multiplierResult)
-        let multiplicandResults = (0..<multiplicandCount).map { _ in c(Int(arc4random_uniform(100)) + 1) }
-        let expectedValue = multiplicandResults.reduce(0) { $0 - $1.value }
-        let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: multiplicandResults)
+        property("value with positive multiplier") <- forAll {
+            (a: ArrayOf<Constant>) in
+            
+            let a = a.getArray
         
-        let value = result.value
-        
-        expect(value) == expectedValue
+            let multiplierResult = -a.count
+            let multiplicandResults = a
+            let expectedValue = multiplicandResults.reduce(0) { $0 - $1.value }
+            let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: multiplicandResults)
+            
+            let value = result.value
+            
+            return value == expectedValue
+        }
     }
     
 }

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -22,10 +22,7 @@ extension MultiplicationExpression_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkReflexive { MultiplicationExpression(a, b) }
         }
@@ -33,10 +30,7 @@ extension MultiplicationExpression_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkSymmetric { MultiplicationExpression(a, b) }
         }
@@ -44,10 +38,7 @@ extension MultiplicationExpression_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             return EquatableTestUtilities.checkTransitive { MultiplicationExpression(a, b) }
         }
@@ -55,15 +46,10 @@ extension MultiplicationExpression_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: Int, b: Int, m: Int, n: Int) in
+            (a: Constant, b: Constant, m: Constant, n: Constant) in
             
             // Check only this case since it's not commutative
             guard !(a == m && b == n) else { return true }
-            
-            let a = c(a)
-            let b = c(b)
-            let m = c(m)
-            let n = c(n)
             
             return EquatableTestUtilities.checkNotEquate(
                 { MultiplicationExpression(a, b) },
@@ -74,12 +60,9 @@ extension MultiplicationExpression_Tests {
     
     func test_shouldBeAnticommutative() {
         property("anticommutative") <- forAll {
-            (a: Int, b: Int) in
+            (a: Constant, b: Constant) in
             
             guard a != b else { return true }
-            
-            let a = c(a)
-            let b = c(b)
             
             let x = MultiplicationExpression(a, b)
             let y = MultiplicationExpression(b, a)
@@ -167,10 +150,7 @@ extension MultiplicationExpression_Tests {
     
     func test_probabilityMass_shouldReturnCorrect() {
         property("probability mass") <- forAll {
-            (a: Int, b: Int) in
-            
-            let a = c(a)
-            let b = c(b)
+            (a: Constant, b: Constant) in
             
             let expectedProbMass = a.probabilityMass.product(b.probabilityMass)
             let expression = MultiplicationExpression(a, b)

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -27,9 +27,7 @@ extension MultiplicationExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = MultiplicationExpression(a, b)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive { MultiplicationExpression(a, b) }
         }
     }
     
@@ -40,10 +38,7 @@ extension MultiplicationExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = MultiplicationExpression(a, b)
-            let y = MultiplicationExpression(a, b)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric { MultiplicationExpression(a, b) }
         }
     }
     
@@ -54,11 +49,7 @@ extension MultiplicationExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = MultiplicationExpression(a, b)
-            let y = MultiplicationExpression(a, b)
-            let z = MultiplicationExpression(a, b)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive { MultiplicationExpression(a, b) }
         }
     }
     
@@ -74,10 +65,10 @@ extension MultiplicationExpression_Tests {
             let m = c(m)
             let n = c(n)
             
-            let x = MultiplicationExpression(a, b)
-            let y = MultiplicationExpression(m, n)
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { MultiplicationExpression(a, b) },
+                { MultiplicationExpression(m, n) }
+            )
         }
     }
     

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -96,20 +96,25 @@ extension MultiplicationExpression_Tests {
         
     }
     
-    // TODO: Make a SwiftCheck
     func test_evaluate_shouldCreateResultCorrectly() {
-        let multiplicandResults: [Constant] = [8, 4, 2, -7, 1, 9, 3, 3, -3, 4, 5]
-        let expectedMultiplicandResults = multiplicandResults
-        let leftExpression = c(expectedMultiplicandResults.count)
-        let expectedMultiplierResult = leftExpression
-        let mockRightExpression = MockExpression()
-        mockRightExpression.stubResulter = { multiplicandResults[mockRightExpression.evaluateCalled] }
-        let expression = MultiplicationExpression(leftExpression, mockRightExpression)
+        property("evaluate") <- forAll {
+            (a: ArrayOf<Constant>) in
         
-        let result = expression.evaluate()
-        
-        expect(result.multiplierResult) == expectedMultiplierResult
-        expect(result.multiplicandResults) == expectedMultiplicandResults
+            let multiplicandResults = a.getArray
+            let expectedMultiplicandResults = multiplicandResults
+            let leftExpression = c(expectedMultiplicandResults.count)
+            let expectedMultiplierResult = leftExpression
+            let mockRightExpression = MockExpression()
+            mockRightExpression.stubResulter = { multiplicandResults[mockRightExpression.evaluateCalled] }
+            let expression = MultiplicationExpression(leftExpression, mockRightExpression)
+            
+            let result = expression.evaluate()
+            
+            let testMultiplierResult = result.multiplierResult == expectedMultiplierResult
+            let testMultiplicandResults = result.multiplicandResults == expectedMultiplicandResults
+            
+            return testMultiplierResult && testMultiplicandResults
+        }
     }
 
 }

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -48,13 +48,13 @@ extension MultiplicationExpression_Tests {
         property("non-equal") <- forAll {
             (a: Constant, b: Constant, m: Constant, n: Constant) in
             
-            // Check only this case since it's not commutative
-            guard !(a == m && b == n) else { return true }
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { MultiplicationExpression(a, b) },
-                { MultiplicationExpression(m, n) }
-            )
+            // Only check one set of parameters since not commutitive
+            return (a != m || b != n) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { MultiplicationExpression(a, b) },
+                    { MultiplicationExpression(m, n) }
+                )
+            }
         }
     }
     
@@ -62,12 +62,12 @@ extension MultiplicationExpression_Tests {
         property("anticommutative") <- forAll {
             (a: Constant, b: Constant) in
             
-            guard a != b else { return true }
-            
-            let x = MultiplicationExpression(a, b)
-            let y = MultiplicationExpression(b, a)
-            
-            return x != y
+            return (a != b) ==> {
+                let x = MultiplicationExpression(a, b)
+                let y = MultiplicationExpression(b, a)
+                
+                return x != y
+            }
         }
     }
 

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -119,9 +119,8 @@ extension MultiplicationExpression_Tests {
     
     func test_operator_shouldWorkWithIntAndExpression() {
         property("Int * Expression and Expression * Int returns correct MultiplicationExpression") <- forAll {
-            (a: Int, b: Int) in
+            (a: Int, die: Die) in
             
-            let die = d(b)
             let expectedExpression1 = MultiplicationExpression(c(a), die)
             let expectedExpression2 = MultiplicationExpression(die, c(a))
             
@@ -136,13 +135,11 @@ extension MultiplicationExpression_Tests {
     
     func test_operator_shouldWorkWithExpressionAndExpression() {
         property("Expression * Expression returns correct MultiplicationExpression") <- forAll {
-            (a: Int, b: Int) in
+            (a: Die, b: Die) in
             
-            let leftDie = d(a)
-            let rightDie = d(b)
-            let expectedExpression = MultiplicationExpression(leftDie, rightDie)
+            let expectedExpression = MultiplicationExpression(a, b)
             
-            let expression = leftDie * rightDie
+            let expression = a * b
         
             return expression == expectedExpression
         }

--- a/DiceKitTests/NegationExpressionResult_Tests.swift
+++ b/DiceKitTests/NegationExpressionResult_Tests.swift
@@ -22,9 +22,7 @@ extension NegationExpressionResult_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             return EquatableTestUtilities.checkReflexive { NegationExpressionResult(a) }
         }
@@ -32,9 +30,7 @@ extension NegationExpressionResult_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             return EquatableTestUtilities.checkSymmetric { NegationExpressionResult(a) }
         }
@@ -42,9 +38,7 @@ extension NegationExpressionResult_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             return EquatableTestUtilities.checkTransitive { NegationExpressionResult(a) }
         }
@@ -52,12 +46,9 @@ extension NegationExpressionResult_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: Int, b: Int) in
+            (a: Constant, b: Constant) in
             
             guard a != b else { return true }
-            
-            let a = c(a)
-            let b = c(b)
             
             return EquatableTestUtilities.checkNotEquate(
                 { NegationExpressionResult(a) },
@@ -73,10 +64,10 @@ extension NegationExpressionResult_Tests {
     
     func test_value_shouldNegateTheBaseResult() {
         property("negate the base result") <- forAll {
-            (a: Int) in
+            (a: Constant) in
             
-            let expectedValue = -a
-            let result = NegationExpressionResult(c(a))
+            let expectedValue = -a.value
+            let result = NegationExpressionResult(a)
             
             let value = result.value
             

--- a/DiceKitTests/NegationExpressionResult_Tests.swift
+++ b/DiceKitTests/NegationExpressionResult_Tests.swift
@@ -48,12 +48,12 @@ extension NegationExpressionResult_Tests {
         property("non-equal") <- forAll {
             (a: Constant, b: Constant) in
             
-            guard a != b else { return true }
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { NegationExpressionResult(a) },
-                { NegationExpressionResult(b) }
-            )
+            return (a != b) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { NegationExpressionResult(a) },
+                    { NegationExpressionResult(b) }
+                )
+            }
         }
     }
     

--- a/DiceKitTests/NegationExpressionResult_Tests.swift
+++ b/DiceKitTests/NegationExpressionResult_Tests.swift
@@ -26,9 +26,7 @@ extension NegationExpressionResult_Tests {
             
             let a = c(a)
             
-            let x = NegationExpressionResult(a)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive { NegationExpressionResult(a) }
         }
     }
     
@@ -38,10 +36,7 @@ extension NegationExpressionResult_Tests {
             
             let a = c(a)
             
-            let x = NegationExpressionResult(a)
-            let y = NegationExpressionResult(a)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric { NegationExpressionResult(a) }
         }
     }
     
@@ -51,11 +46,7 @@ extension NegationExpressionResult_Tests {
             
             let a = c(a)
             
-            let x = NegationExpressionResult(a)
-            let y = NegationExpressionResult(a)
-            let z = NegationExpressionResult(a)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive { NegationExpressionResult(a) }
         }
     }
     
@@ -68,10 +59,10 @@ extension NegationExpressionResult_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = NegationExpressionResult(a)
-            let y = NegationExpressionResult(b)
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { NegationExpressionResult(a) },
+                { NegationExpressionResult(b) }
+            )
         }
     }
     

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -48,12 +48,12 @@ extension NegationExpression_Tests {
         property("non-equal") <- forAll {
             (a: Constant, b: Constant) in
             
-            guard a != b else { return true }
-            
-            return EquatableTestUtilities.checkNotEquate(
-                { NegationExpression(a) },
-                { NegationExpression(b) }
-            )
+            return (a != b) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { NegationExpression(a) },
+                    { NegationExpression(b) }
+                )
+            }
         }
     }
     

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -22,9 +22,7 @@ extension NegationExpression_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             return EquatableTestUtilities.checkReflexive { NegationExpression(a) }
         }
@@ -32,9 +30,7 @@ extension NegationExpression_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             return EquatableTestUtilities.checkSymmetric { NegationExpression(a) }
         }
@@ -42,9 +38,7 @@ extension NegationExpression_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             return EquatableTestUtilities.checkTransitive { NegationExpression(a) }
         }
@@ -52,12 +46,9 @@ extension NegationExpression_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: Int, b: Int) in
+            (a: Constant, b: Constant) in
             
             guard a != b else { return true }
-            
-            let a = c(a)
-            let b = c(b)
             
             return EquatableTestUtilities.checkNotEquate(
                 { NegationExpression(a) },
@@ -73,9 +64,8 @@ extension NegationExpression_Tests {
     
     func test_evaluate_shouldCreateResultCorrectly() {
         property("create results") <- forAll {
-            (a: Int) in
+            (a: Constant) in
             
-            let a = c(a)
             let expression = NegationExpression(a)
             
             let result = expression.evaluate()
@@ -86,9 +76,7 @@ extension NegationExpression_Tests {
     
     func test_probabilityMass_shouldReturnCorrect() {
         property("probability mass") <- forAll {
-            (a: Int) in
-            
-            let a = c(a)
+            (a: Constant) in
             
             let expectedProbMass = a.probabilityMass.negate()
             let expression = NegationExpression(a)

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -94,9 +94,9 @@ extension NegationExpression_Tests {
     
     func test_operator_shouldWorkOnExpression() {
         property("-Expression should make correct NegationExpression") <- forAll {
-            (m: Int, n: Int, o: Int) in
+            (m: Constant, n: Constant, o: Die) in
             
-            let baseExpression = c(m) + c(n) * d(o)
+            let baseExpression = m + n * o
             let expectedExpression = NegationExpression(baseExpression)
             
             let expression = -baseExpression

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -26,9 +26,7 @@ extension NegationExpression_Tests {
             
             let a = c(a)
             
-            let x = NegationExpression(a)
-            
-            return x == x
+            return EquatableTestUtilities.checkReflexive { NegationExpression(a) }
         }
     }
     
@@ -38,10 +36,7 @@ extension NegationExpression_Tests {
             
             let a = c(a)
             
-            let x = NegationExpression(a)
-            let y = NegationExpression(a)
-            
-            return x == y && y == x
+            return EquatableTestUtilities.checkSymmetric { NegationExpression(a) }
         }
     }
     
@@ -51,11 +46,7 @@ extension NegationExpression_Tests {
             
             let a = c(a)
             
-            let x = NegationExpression(a)
-            let y = NegationExpression(a)
-            let z = NegationExpression(a)
-            
-            return x == y && y == z && x == z
+            return EquatableTestUtilities.checkTransitive { NegationExpression(a) }
         }
     }
     
@@ -68,10 +59,10 @@ extension NegationExpression_Tests {
             let a = c(a)
             let b = c(b)
             
-            let x = NegationExpression(a)
-            let y = NegationExpression(b)
-            
-            return x != y
+            return EquatableTestUtilities.checkNotEquate(
+                { NegationExpression(a) },
+                { NegationExpression(b) }
+            )
         }
     }
     

--- a/DiceKitTests/ProbabilityMass_Tests.swift
+++ b/DiceKitTests/ProbabilityMass_Tests.swift
@@ -52,7 +52,42 @@ extension ProbabilityMass_Tests {
 // MARK: - Equatable
 extension ProbabilityMass_Tests {
     
-    // TODO: Equatable
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (a: FrequencyDistribution) in
+            
+            return EquatableTestUtilities.checkReflexive { ProbabilityMass(a) }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (a: FrequencyDistribution) in
+            
+            return EquatableTestUtilities.checkSymmetric { ProbabilityMass(a) }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (a: FrequencyDistribution) in
+            
+            return EquatableTestUtilities.checkTransitive { ProbabilityMass(a) }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: FrequencyDistribution, b: FrequencyDistribution) in
+            
+            return !(a.normalizeFrequencies().approximatelyEqual(b.normalizeFrequencies(), delta: ProbabilityMass.defaultProbabilityEqualityDelta) ) ==> {
+                return EquatableTestUtilities.checkNotEquate(
+                    { ProbabilityMass(a) },
+                    { ProbabilityMass(b) }
+                )
+            }
+        }
+    }
     
 }
 

--- a/DiceKitTests/ProbabilityMass_Tests.swift
+++ b/DiceKitTests/ProbabilityMass_Tests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import Nimble
+import SwiftCheck
 
 import DiceKit
 
@@ -23,21 +24,27 @@ class ProbabilityMass_Tests: XCTestCase {
 extension ProbabilityMass_Tests {
     
     func test_init_shouldNormalizeFrequencyDistribution() {
-        let freqDist = FrequencyDistribution([1: 1.0, 2: 6.0, 6: 3.0])
-        let expectedFreqDist = freqDist.normalizeFrequencies()
-        
-        let probMass = ProbabilityMass(freqDist)
-        
-        expect(probMass.frequencyDistribution) == expectedFreqDist
+        property("init with frequency distribution") <- forAll {
+            (a: FrequencyDistribution) in
+            
+            let expectedFreqDist = a.normalizeFrequencies()
+            
+            let probMass = ProbabilityMass(a)
+            
+            return probMass.frequencyDistribution == expectedFreqDist
+        }
     }
     
     func test_init_shouldWorkWithConstant() {
-        let constant = 8
-        let expectedFreqDist = FrequencyDistribution([constant: 1.0])
+        property("init with constant") <- forAll {
+            (a: Int) in
         
-        let probMass = ProbabilityMass(constant)
-        
-        expect(probMass.frequencyDistribution) == expectedFreqDist
+            let expectedFreqDist = FrequencyDistribution([a: 1.0])
+            
+            let probMass = ProbabilityMass(a)
+            
+            return probMass.frequencyDistribution == expectedFreqDist
+        }
     }
     
 }


### PR DESCRIPTION
Closes #54.
- Less boilerplate `Equatable` tests
- Conformance to `Arbitrary` for some of our types, to make SwiftCheck tests nicer
- Use SwiftCheck's precondition feature, instead of `guard`
- Convert more tests to SwiftCheck
- Add missing `Equatable` tests
- Fix a couple bugs found by new tests
