### PR TITLE
[WIP] Successfulness

### DIFF
--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		533F88091B52B988003838C8 /* DiceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 533F87FE1B52B988003838C8 /* DiceKit.framework */; };
 		533F880E1B52B988003838C8 /* Die_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533F880D1B52B988003838C8 /* Die_Tests.swift */; };
 		533F88191B52BC6F003838C8 /* DiceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 533F88181B52BC6F003838C8 /* DiceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		534900321B76FC7E00FA2804 /* OutcomeWithSuccessfulness_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534900311B76FC7E00FA2804 /* OutcomeWithSuccessfulness_Tests.swift */; };
 		534900341B78172900FA2804 /* ArithmeticType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534900331B78172900FA2804 /* ArithmeticType.swift */; };
 		5379780B1B531B21005818EC /* Die.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5379780A1B531B21005818EC /* Die.swift */; };
 		538743871B5316BA00EB15C8 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 530FEDD11B530CAB00960BFD /* Nimble.framework */; };
@@ -34,7 +35,10 @@
 		539D568C1B5C7B7700AC6A37 /* Dictionary+Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D568B1B5C7B7700AC6A37 /* Dictionary+Functions.swift */; };
 		539D568E1B5C7BDA00AC6A37 /* ProbabilityMass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */; };
 		539EAC5B1B6DB97C0097C116 /* FrequencyDistributionIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5A1B6DB97C0097C116 /* FrequencyDistributionIndex.swift */; };
+		539EAC5D1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */; };
+		539EAC651B6EDA630097C116 /* Successfulness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC641B6EDA630097C116 /* Successfulness.swift */; };
 		539EAC671B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */; };
+		53BA535A1B76D90400F0944C /* Successfulness_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BA53591B76D90400F0944C /* Successfulness_Tests.swift */; };
 		53CFC30D1B5AD3BF009C6C8F /* ExpressionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CFC30C1B5AD3BF009C6C8F /* ExpressionType.swift */; };
 		53CFC30F1B5AD674009C6C8F /* MultiplicationExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CFC30E1B5AD674009C6C8F /* MultiplicationExpression.swift */; };
 		53CFC3111B5AE4A0009C6C8F /* MultiplicationExpression_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CFC3101B5AE4A0009C6C8F /* MultiplicationExpression_Tests.swift */; };
@@ -105,6 +109,7 @@
 		533F880D1B52B988003838C8 /* Die_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Die_Tests.swift; sourceTree = "<group>"; };
 		533F880F1B52B988003838C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		533F88181B52BC6F003838C8 /* DiceKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DiceKit.h; sourceTree = "<group>"; };
+		534900311B76FC7E00FA2804 /* OutcomeWithSuccessfulness_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutcomeWithSuccessfulness_Tests.swift; sourceTree = "<group>"; };
 		534900331B78172900FA2804 /* ArithmeticType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArithmeticType.swift; sourceTree = "<group>"; };
 		5379780A1B531B21005818EC /* Die.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.swift; sourceTree = "<group>"; };
 		538AD9641B75A66F001B5CB5 /* MockExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockExpression.swift; sourceTree = "<group>"; };
@@ -119,7 +124,10 @@
 		539D568B1B5C7B7700AC6A37 /* Dictionary+Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Functions.swift"; sourceTree = "<group>"; };
 		539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilityMass.swift; sourceTree = "<group>"; };
 		539EAC5A1B6DB97C0097C116 /* FrequencyDistributionIndex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistributionIndex.swift; sourceTree = "<group>"; };
+		539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutcomeWithSuccessfulness.swift; sourceTree = "<group>"; };
+		539EAC641B6EDA630097C116 /* Successfulness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Successfulness.swift; sourceTree = "<group>"; };
 		539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistributionIndex_Tests.swift; sourceTree = "<group>"; };
+		53BA53591B76D90400F0944C /* Successfulness_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Successfulness_Tests.swift; sourceTree = "<group>"; };
 		53CFC30C1B5AD3BF009C6C8F /* ExpressionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpressionType.swift; sourceTree = "<group>"; };
 		53CFC30E1B5AD674009C6C8F /* MultiplicationExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiplicationExpression.swift; sourceTree = "<group>"; };
 		53CFC3101B5AE4A0009C6C8F /* MultiplicationExpression_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiplicationExpression_Tests.swift; sourceTree = "<group>"; };
@@ -235,12 +243,14 @@
 				531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */,
 				53ECD0E11B5B498A002D859F /* NegationExpression.swift */,
 				53ECD0E31B5B5185002D859F /* NegationExpressionResult.swift */,
+				539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */,
 				53FA0EAB1B6579F300C8D3B5 /* ProbabilisticExpressionType.swift */,
 				539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */,
 				6E9F188F1B7FCD4400AB8893 /* MinimizationExpression.swift */,
 				6E9F18971B7FDF0D00AB8893 /* MinimizationExpressionResult.swift */,
 				6E9F18911B7FCD5400AB8893 /* MaximizationExpression.swift */,
 				6E9F189B1B7FDFF900AB8893 /* MaximizationExpressionResult.swift */,
+				539EAC641B6EDA630097C116 /* Successfulness.swift */,
 			);
 			path = DiceKit;
 			sourceTree = "<group>";
@@ -267,12 +277,14 @@
 				539D56851B5B6D2B00AC6A37 /* NegationExpressionResult_Tests.swift */,
 				8BFAA9F81B7ED8E800EF65AE /* SubtractionExpression_Tests.swift */,
 				8BFAA9FA1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift */,
+				534900311B76FC7E00FA2804 /* OutcomeWithSuccessfulness_Tests.swift */,
 				53FA0EAD1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift */,
 				533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */,
 				6E9F18931B7FD16100AB8893 /* MinimizationExpression_Tests.swift */,
 				6E0F58C81B8D63690095087F /* MinimizationExpressionResult_Tests.swift */,
 				6E9F18951B7FD18600AB8893 /* MaximizationExpression_Tests.swift */,
 				6E0F58CA1B8D63910095087F /* MaximizationExpressionResult_Tests.swift */,
+				53BA53591B76D90400F0944C /* Successfulness_Tests.swift */,
 			);
 			path = DiceKitTests;
 			sourceTree = "<group>";
@@ -420,7 +432,9 @@
 				539D56821B5B69D700AC6A37 /* ExpressionResultType.swift in Sources */,
 				539D567E1B5B66CF00AC6A37 /* AdditionExpression.swift in Sources */,
 				53D1EC7C1B6312E100433D2C /* FrequencyDistribution.swift in Sources */,
+				539EAC5D1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift in Sources */,
 				53FA0EAC1B6579F300C8D3B5 /* ProbabilisticExpressionType.swift in Sources */,
+				539EAC651B6EDA630097C116 /* Successfulness.swift in Sources */,
 				531084C01B5AF993008DD696 /* MultiplicationExpressionResult.swift in Sources */,
 				539D568C1B5C7B7700AC6A37 /* Dictionary+Functions.swift in Sources */,
 				6E9F18981B7FDF0D00AB8893 /* MinimizationExpressionResult.swift in Sources */,
@@ -456,6 +470,7 @@
 				53D05EEC1B546C73007CE7FC /* Int+Random_Tests.swift in Sources */,
 				6E9F18941B7FD16100AB8893 /* MinimizationExpression_Tests.swift in Sources */,
 				539D568A1B5B6D6A00AC6A37 /* AdditionExpressionResult_Tests.swift in Sources */,
+				534900321B76FC7E00FA2804 /* OutcomeWithSuccessfulness_Tests.swift in Sources */,
 				533D0C771B6419F8003A7D32 /* FrequencyDistribution_Tests.swift in Sources */,
 				6E0F58C91B8D63690095087F /* MinimizationExpressionResult_Tests.swift in Sources */,
 				538AD96B1B768931001B5CB5 /* Constant_Tests.swift in Sources */,
@@ -470,6 +485,7 @@
 				531E4F5F1B73F5E20073F01A /* EquatableTestUtilities.swift in Sources */,
 				8BFAA9FB1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift in Sources */,
 				533D0C7B1B6423FA003A7D32 /* ProbabilityMass_Tests.swift in Sources */,
+				53BA535A1B76D90400F0944C /* Successfulness_Tests.swift in Sources */,
 				53D1EC801B63DF0C00433D2C /* Dictionary+Functions_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		539D568E1B5C7BDA00AC6A37 /* ProbabilityMass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */; };
 		539EAC5B1B6DB97C0097C116 /* FrequencyDistributionIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5A1B6DB97C0097C116 /* FrequencyDistributionIndex.swift */; };
 		539EAC5D1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */; };
+		539EAC631B6EC3310097C116 /* SuccessfulnessResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC621B6EC3310097C116 /* SuccessfulnessResultType.swift */; };
 		539EAC651B6EDA630097C116 /* Successfulness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC641B6EDA630097C116 /* Successfulness.swift */; };
 		539EAC671B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */; };
 		53BA535A1B76D90400F0944C /* Successfulness_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BA53591B76D90400F0944C /* Successfulness_Tests.swift */; };
@@ -125,6 +126,7 @@
 		539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilityMass.swift; sourceTree = "<group>"; };
 		539EAC5A1B6DB97C0097C116 /* FrequencyDistributionIndex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistributionIndex.swift; sourceTree = "<group>"; };
 		539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutcomeWithSuccessfulness.swift; sourceTree = "<group>"; };
+		539EAC621B6EC3310097C116 /* SuccessfulnessResultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessResultType.swift; sourceTree = "<group>"; };
 		539EAC641B6EDA630097C116 /* Successfulness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Successfulness.swift; sourceTree = "<group>"; };
 		539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistributionIndex_Tests.swift; sourceTree = "<group>"; };
 		53BA53591B76D90400F0944C /* Successfulness_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Successfulness_Tests.swift; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 				6E9F18911B7FCD5400AB8893 /* MaximizationExpression.swift */,
 				6E9F189B1B7FDFF900AB8893 /* MaximizationExpressionResult.swift */,
 				539EAC641B6EDA630097C116 /* Successfulness.swift */,
+				539EAC621B6EC3310097C116 /* SuccessfulnessResultType.swift */,
 			);
 			path = DiceKit;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				534900341B78172900FA2804 /* ArithmeticType.swift in Sources */,
 				6E9F18921B7FCD5400AB8893 /* MaximizationExpression.swift in Sources */,
 				539D56821B5B69D700AC6A37 /* ExpressionResultType.swift in Sources */,
+				539EAC631B6EC3310097C116 /* SuccessfulnessResultType.swift in Sources */,
 				539D567E1B5B66CF00AC6A37 /* AdditionExpression.swift in Sources */,
 				53D1EC7C1B6312E100433D2C /* FrequencyDistribution.swift in Sources */,
 				539EAC5D1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift in Sources */,

--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -9,8 +9,12 @@
 /* Begin PBXBuildFile section */
 		531084C01B5AF993008DD696 /* MultiplicationExpressionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */; };
 		531084C31B5B0761008DD696 /* Die.Roll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531084C11B5B0102008DD696 /* Die.Roll.swift */; };
+		531E4F591B73EDBA0073F01A /* SuccessfulnessExpression.Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F581B73EDBA0073F01A /* SuccessfulnessExpression.Comparison.swift */; };
+		531E4F5B1B73EE9F0073F01A /* SuccessfulnessExpression.Comparison.Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F5A1B73EE9F0073F01A /* SuccessfulnessExpression.Comparison.Operation.swift */; };
+		531E4F5D1B73EF4D0073F01A /* SuccessfulnessExpression.Comparison.Operation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F5C1B73EF4D0073F01A /* SuccessfulnessExpression.Comparison.Operation_Tests.swift */; };
 		531E4F5F1B73F5E20073F01A /* EquatableTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */; };
 		531E4F611B7400270073F01A /* Arbitrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531E4F601B7400270073F01A /* Arbitrary.swift */; };
+		533C9D5A1B73D0FA0023AB95 /* SuccessfulnessExpression_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533C9D591B73D0FA0023AB95 /* SuccessfulnessExpression_Tests.swift */; };
 		533D0C771B6419F8003A7D32 /* FrequencyDistribution_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */; };
 		533D0C7B1B6423FA003A7D32 /* ProbabilityMass_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */; };
 		533D0C7D1B643F6C003A7D32 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533D0C7C1B643F6C003A7D32 /* Constant.swift */; };
@@ -22,7 +26,9 @@
 		534900341B78172900FA2804 /* ArithmeticType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534900331B78172900FA2804 /* ArithmeticType.swift */; };
 		5379780B1B531B21005818EC /* Die.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5379780A1B531B21005818EC /* Die.swift */; };
 		538743871B5316BA00EB15C8 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 530FEDD11B530CAB00960BFD /* Nimble.framework */; };
+		538AD9631B757630001B5CB5 /* SuccessfulnessExpressionResult_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538AD9621B757630001B5CB5 /* SuccessfulnessExpressionResult_Tests.swift */; };
 		538AD9651B75A66F001B5CB5 /* MockExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538AD9641B75A66F001B5CB5 /* MockExpression.swift */; };
+		538AD9671B75AD63001B5CB5 /* SuccessfulnessExpressionResult.Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538AD9661B75AD63001B5CB5 /* SuccessfulnessExpressionResult.Comparison.swift */; };
 		538AD9691B7678B7001B5CB5 /* Die.Roll_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538AD9681B7678B7001B5CB5 /* Die.Roll_Tests.swift */; };
 		538AD96B1B768931001B5CB5 /* Constant_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538AD96A1B768931001B5CB5 /* Constant_Tests.swift */; };
 		539D567E1B5B66CF00AC6A37 /* AdditionExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D567D1B5B66CF00AC6A37 /* AdditionExpression.swift */; };
@@ -36,6 +42,8 @@
 		539D568E1B5C7BDA00AC6A37 /* ProbabilityMass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */; };
 		539EAC5B1B6DB97C0097C116 /* FrequencyDistributionIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5A1B6DB97C0097C116 /* FrequencyDistributionIndex.swift */; };
 		539EAC5D1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */; };
+		539EAC5F1B6EC0010097C116 /* SuccessfulnessExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC5E1B6EC0010097C116 /* SuccessfulnessExpression.swift */; };
+		539EAC611B6EC0C60097C116 /* SuccessfulnessExpressionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC601B6EC0C60097C116 /* SuccessfulnessExpressionResult.swift */; };
 		539EAC631B6EC3310097C116 /* SuccessfulnessResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC621B6EC3310097C116 /* SuccessfulnessResultType.swift */; };
 		539EAC651B6EDA630097C116 /* Successfulness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC641B6EDA630097C116 /* Successfulness.swift */; };
 		539EAC671B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */; };
@@ -98,8 +106,12 @@
 		531084BD1B5AF859008DD696 /* ExpressionResultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpressionResultType.swift; sourceTree = "<group>"; };
 		531084BF1B5AF993008DD696 /* MultiplicationExpressionResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiplicationExpressionResult.swift; sourceTree = "<group>"; };
 		531084C11B5B0102008DD696 /* Die.Roll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.Roll.swift; sourceTree = "<group>"; };
+		531E4F581B73EDBA0073F01A /* SuccessfulnessExpression.Comparison.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpression.Comparison.swift; sourceTree = "<group>"; };
+		531E4F5A1B73EE9F0073F01A /* SuccessfulnessExpression.Comparison.Operation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpression.Comparison.Operation.swift; sourceTree = "<group>"; };
+		531E4F5C1B73EF4D0073F01A /* SuccessfulnessExpression.Comparison.Operation_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpression.Comparison.Operation_Tests.swift; sourceTree = "<group>"; };
 		531E4F5E1B73F5E20073F01A /* EquatableTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EquatableTestUtilities.swift; sourceTree = "<group>"; };
 		531E4F601B7400270073F01A /* Arbitrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arbitrary.swift; sourceTree = "<group>"; };
+		533C9D591B73D0FA0023AB95 /* SuccessfulnessExpression_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpression_Tests.swift; sourceTree = "<group>"; };
 		533D0C761B6419F8003A7D32 /* FrequencyDistribution_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistribution_Tests.swift; sourceTree = "<group>"; };
 		533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilityMass_Tests.swift; sourceTree = "<group>"; };
 		533D0C7C1B643F6C003A7D32 /* Constant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
@@ -113,7 +125,9 @@
 		534900311B76FC7E00FA2804 /* OutcomeWithSuccessfulness_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutcomeWithSuccessfulness_Tests.swift; sourceTree = "<group>"; };
 		534900331B78172900FA2804 /* ArithmeticType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArithmeticType.swift; sourceTree = "<group>"; };
 		5379780A1B531B21005818EC /* Die.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.swift; sourceTree = "<group>"; };
+		538AD9621B757630001B5CB5 /* SuccessfulnessExpressionResult_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpressionResult_Tests.swift; sourceTree = "<group>"; };
 		538AD9641B75A66F001B5CB5 /* MockExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockExpression.swift; sourceTree = "<group>"; };
+		538AD9661B75AD63001B5CB5 /* SuccessfulnessExpressionResult.Comparison.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpressionResult.Comparison.swift; sourceTree = "<group>"; };
 		538AD9681B7678B7001B5CB5 /* Die.Roll_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Die.Roll_Tests.swift; sourceTree = "<group>"; };
 		538AD96A1B768931001B5CB5 /* Constant_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constant_Tests.swift; sourceTree = "<group>"; };
 		539D567D1B5B66CF00AC6A37 /* AdditionExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditionExpression.swift; sourceTree = "<group>"; };
@@ -126,6 +140,8 @@
 		539D568D1B5C7BDA00AC6A37 /* ProbabilityMass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilityMass.swift; sourceTree = "<group>"; };
 		539EAC5A1B6DB97C0097C116 /* FrequencyDistributionIndex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistributionIndex.swift; sourceTree = "<group>"; };
 		539EAC5C1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutcomeWithSuccessfulness.swift; sourceTree = "<group>"; };
+		539EAC5E1B6EC0010097C116 /* SuccessfulnessExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpression.swift; sourceTree = "<group>"; };
+		539EAC601B6EC0C60097C116 /* SuccessfulnessExpressionResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessExpressionResult.swift; sourceTree = "<group>"; };
 		539EAC621B6EC3310097C116 /* SuccessfulnessResultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuccessfulnessResultType.swift; sourceTree = "<group>"; };
 		539EAC641B6EDA630097C116 /* Successfulness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Successfulness.swift; sourceTree = "<group>"; };
 		539EAC661B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrequencyDistributionIndex_Tests.swift; sourceTree = "<group>"; };
@@ -253,6 +269,11 @@
 				6E9F18911B7FCD5400AB8893 /* MaximizationExpression.swift */,
 				6E9F189B1B7FDFF900AB8893 /* MaximizationExpressionResult.swift */,
 				539EAC641B6EDA630097C116 /* Successfulness.swift */,
+				539EAC5E1B6EC0010097C116 /* SuccessfulnessExpression.swift */,
+				531E4F581B73EDBA0073F01A /* SuccessfulnessExpression.Comparison.swift */,
+				531E4F5A1B73EE9F0073F01A /* SuccessfulnessExpression.Comparison.Operation.swift */,
+				539EAC601B6EC0C60097C116 /* SuccessfulnessExpressionResult.swift */,
+				538AD9661B75AD63001B5CB5 /* SuccessfulnessExpressionResult.Comparison.swift */,
 				539EAC621B6EC3310097C116 /* SuccessfulnessResultType.swift */,
 			);
 			path = DiceKit;
@@ -288,6 +309,9 @@
 				6E9F18951B7FD18600AB8893 /* MaximizationExpression_Tests.swift */,
 				6E0F58CA1B8D63910095087F /* MaximizationExpressionResult_Tests.swift */,
 				53BA53591B76D90400F0944C /* Successfulness_Tests.swift */,
+				533C9D591B73D0FA0023AB95 /* SuccessfulnessExpression_Tests.swift */,
+				531E4F5C1B73EF4D0073F01A /* SuccessfulnessExpression.Comparison.Operation_Tests.swift */,
+				538AD9621B757630001B5CB5 /* SuccessfulnessExpressionResult_Tests.swift */,
 			);
 			path = DiceKitTests;
 			sourceTree = "<group>";
@@ -433,13 +457,16 @@
 				534900341B78172900FA2804 /* ArithmeticType.swift in Sources */,
 				6E9F18921B7FCD5400AB8893 /* MaximizationExpression.swift in Sources */,
 				539D56821B5B69D700AC6A37 /* ExpressionResultType.swift in Sources */,
+				531E4F5B1B73EE9F0073F01A /* SuccessfulnessExpression.Comparison.Operation.swift in Sources */,
 				539EAC631B6EC3310097C116 /* SuccessfulnessResultType.swift in Sources */,
 				539D567E1B5B66CF00AC6A37 /* AdditionExpression.swift in Sources */,
+				539EAC611B6EC0C60097C116 /* SuccessfulnessExpressionResult.swift in Sources */,
 				53D1EC7C1B6312E100433D2C /* FrequencyDistribution.swift in Sources */,
 				539EAC5D1B6E967F0097C116 /* OutcomeWithSuccessfulness.swift in Sources */,
 				53FA0EAC1B6579F300C8D3B5 /* ProbabilisticExpressionType.swift in Sources */,
 				539EAC651B6EDA630097C116 /* Successfulness.swift in Sources */,
 				531084C01B5AF993008DD696 /* MultiplicationExpressionResult.swift in Sources */,
+				539EAC5F1B6EC0010097C116 /* SuccessfulnessExpression.swift in Sources */,
 				539D568C1B5C7B7700AC6A37 /* Dictionary+Functions.swift in Sources */,
 				6E9F18981B7FDF0D00AB8893 /* MinimizationExpressionResult.swift in Sources */,
 				53D1EC7E1B63133E00433D2C /* ApproximatelyEquatable.swift in Sources */,
@@ -455,8 +482,10 @@
 				6E9F18901B7FCD4400AB8893 /* MinimizationExpression.swift in Sources */,
 				6E9F189C1B7FDFF900AB8893 /* MaximizationExpressionResult.swift in Sources */,
 				53CFC30D1B5AD3BF009C6C8F /* ExpressionType.swift in Sources */,
+				538AD9671B75AD63001B5CB5 /* SuccessfulnessExpressionResult.Comparison.swift in Sources */,
 				53CFC30F1B5AD674009C6C8F /* MultiplicationExpression.swift in Sources */,
 				53ECD0E41B5B5185002D859F /* NegationExpressionResult.swift in Sources */,
+				531E4F591B73EDBA0073F01A /* SuccessfulnessExpression.Comparison.swift in Sources */,
 				533D0C7D1B643F6C003A7D32 /* Constant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -471,6 +500,7 @@
 				531E4F611B7400270073F01A /* Arbitrary.swift in Sources */,
 				533EB1EE1B5B293000B3F8A1 /* MultiplicationExpressionResult_Tests.swift in Sources */,
 				53CFC3111B5AE4A0009C6C8F /* MultiplicationExpression_Tests.swift in Sources */,
+				533C9D5A1B73D0FA0023AB95 /* SuccessfulnessExpression_Tests.swift in Sources */,
 				53D05EEC1B546C73007CE7FC /* Int+Random_Tests.swift in Sources */,
 				6E9F18941B7FD16100AB8893 /* MinimizationExpression_Tests.swift in Sources */,
 				539D568A1B5B6D6A00AC6A37 /* AdditionExpressionResult_Tests.swift in Sources */,
@@ -478,9 +508,11 @@
 				533D0C771B6419F8003A7D32 /* FrequencyDistribution_Tests.swift in Sources */,
 				6E0F58C91B8D63690095087F /* MinimizationExpressionResult_Tests.swift in Sources */,
 				538AD96B1B768931001B5CB5 /* Constant_Tests.swift in Sources */,
+				538AD9631B757630001B5CB5 /* SuccessfulnessExpressionResult_Tests.swift in Sources */,
 				533F880E1B52B988003838C8 /* Die_Tests.swift in Sources */,
 				6E0F58CB1B8D63910095087F /* MaximizationExpressionResult_Tests.swift in Sources */,
 				539D56861B5B6D2B00AC6A37 /* NegationExpressionResult_Tests.swift in Sources */,
+				531E4F5D1B73EF4D0073F01A /* SuccessfulnessExpression.Comparison.Operation_Tests.swift in Sources */,
 				539D56881B5B6D4A00AC6A37 /* AdditionExpression_Tests.swift in Sources */,
 				6E9F18961B7FD18600AB8893 /* MaximizationExpression_Tests.swift in Sources */,
 				539EAC671B6EF76A0097C116 /* FrequencyDistributionIndex_Tests.swift in Sources */,

--- a/DiceKit/AdditionExpressionResult.swift
+++ b/DiceKit/AdditionExpressionResult.swift
@@ -54,4 +54,8 @@ extension AdditionExpressionResult: ExpressionResultType {
         return leftAddendResult.value + rightAddendResult.value
     }
     
+    public var successfulness: Successfulness {
+        return leftAddendResult.successfulness + rightAddendResult.successfulness
+    }
+    
 }

--- a/DiceKit/Constant.swift
+++ b/DiceKit/Constant.swift
@@ -12,6 +12,8 @@ public struct Constant: Equatable {
     
     public let value: Int
     
+    public let successfulness = Successfulness.Undetermined
+    
     public init(_ value: Int) {
         self.value = value
     }
@@ -82,5 +84,5 @@ extension Constant: ExpressionType {
 // MARK: - ExpressionResultType
 
 extension Constant: ExpressionResultType {
-     // Already conforms because of `value`
+     // Already conforms because of `value` and `successful`
 }

--- a/DiceKit/Die.Roll.swift
+++ b/DiceKit/Die.Roll.swift
@@ -16,6 +16,8 @@ extension Die {
         public let die: Die
         public let value: Int
         
+        public let successfulness = Successfulness.Undetermined
+        
         public init(die: Die, value: Int) {
             self.die = die
             self.value = value
@@ -27,7 +29,7 @@ extension Die {
 // MARK: - ExpressionResultType
 
 extension Die.Roll: ExpressionResultType {
-    // Already conforms because of `value`
+    // Already conforms because of `value` and `successful`
 }
 
 // MARK: - CustomStringConvertible

--- a/DiceKit/ExpressionResultType.swift
+++ b/DiceKit/ExpressionResultType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol ExpressionResultType {
+public protocol ExpressionResultType: SuccessfulnessResultType {
     
     var value: Int { get }
     

--- a/DiceKit/MaximizationExpressionResult.swift
+++ b/DiceKit/MaximizationExpressionResult.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public struct MaximizationExpressionResult<MaximizationExpressionResult: protocol<ExpressionResultType, Equatable>>: Equatable {
     
-    public let maximizationExpressionResult: Int
+    public let maximizationExpressionResult: ExpressionProbabilityMass.Outcome
     
-    public init(_ maximizationExpressionResult: Int) {
+    public init(_ maximizationExpressionResult: ExpressionProbabilityMass.Outcome) {
         self.maximizationExpressionResult = maximizationExpressionResult
     }
     
@@ -50,6 +50,10 @@ extension MaximizationExpressionResult: ExpressionResultType {
     
     public var value: Int {
         return maximizationExpressionResult
+    }
+
+    public var successfulness: Successfulness {
+        return .Undetermined
     }
     
 }

--- a/DiceKit/MaximizationExpressionResult.swift
+++ b/DiceKit/MaximizationExpressionResult.swift
@@ -49,11 +49,11 @@ public func == <L>(lhs: MaximizationExpressionResult<L>, rhs: MaximizationExpres
 extension MaximizationExpressionResult: ExpressionResultType {
     
     public var value: Int {
-        return maximizationExpressionResult
+        return maximizationExpressionResult.outcome
     }
 
     public var successfulness: Successfulness {
-        return .Undetermined
+        return maximizationExpressionResult.successfulness
     }
     
 }

--- a/DiceKit/MinimizationExpressionResult.swift
+++ b/DiceKit/MinimizationExpressionResult.swift
@@ -49,11 +49,11 @@ public func == <L>(lhs: MinimizationExpressionResult<L>, rhs: MinimizationExpres
 extension MinimizationExpressionResult: ExpressionResultType {
     
     public var value: Int {
-        return minimizationExpressionResult
+        return minimizationExpressionResult.outcome
     }
 
     public var successfulness: Successfulness {
-        return .Undetermined
+        return minimizationExpressionResult.successfulness
     }
     
 }

--- a/DiceKit/MinimizationExpressionResult.swift
+++ b/DiceKit/MinimizationExpressionResult.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public struct MinimizationExpressionResult<MinimizationExpressionResult: protocol<ExpressionResultType, Equatable>>: Equatable {
     
-    public let minimizationExpressionResult: Int
+    public let minimizationExpressionResult: ExpressionProbabilityMass.Outcome
     
-    public init(_ minimizationExpressionResult: Int) {
+    public init(_ minimizationExpressionResult: ExpressionProbabilityMass.Outcome) {
         self.minimizationExpressionResult = minimizationExpressionResult
     }
     
@@ -50,6 +50,10 @@ extension MinimizationExpressionResult: ExpressionResultType {
     
     public var value: Int {
         return minimizationExpressionResult
+    }
+
+    public var successfulness: Successfulness {
+        return .Undetermined
     }
     
 }

--- a/DiceKit/MultiplicationExpressionResult.swift
+++ b/DiceKit/MultiplicationExpressionResult.swift
@@ -71,4 +71,9 @@ extension MultiplicationExpressionResult: ExpressionResultType {
         }
     }
     
+    public var successfulness: Successfulness {
+        let successfulnesses = multiplicandResults.map { $0.successfulness }
+        return Successfulness.combineSuccessfulnesses(successfulnesses)
+    }
+    
 }

--- a/DiceKit/NegationExpressionResult.swift
+++ b/DiceKit/NegationExpressionResult.swift
@@ -52,4 +52,8 @@ extension NegationExpressionResult: ExpressionResultType {
         return -base.value
     }
     
+    public var successfulness: Successfulness {
+        return base.successfulness
+    }
+    
 }

--- a/DiceKit/OutcomeWithSuccessfulness.swift
+++ b/DiceKit/OutcomeWithSuccessfulness.swift
@@ -1,0 +1,143 @@
+//
+//  OutcomeWithSuccessfulness.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/2/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+public protocol OutcomeWithSuccessfulnessType {
+    
+    var outcome: Int { get }
+    var successfulness: Successfulness { get }
+    
+    init(_ value: Int, _ successfulness: Successfulness)
+    
+}
+
+// TODO: Determine the best name for this
+public struct OutcomeWithSuccessfulness: OutcomeWithSuccessfulnessType, Comparable, Equatable {
+    
+    public let outcome: Int
+    public let successfulness: Successfulness
+    
+    public init(_ outcome: Int, _ successfulness: Successfulness = .Undetermined) {
+        self.outcome = outcome
+        self.successfulness = successfulness
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+
+extension OutcomeWithSuccessfulness: CustomStringConvertible {
+    
+    public var description: String {
+        switch successfulness {
+        case .Undetermined:
+            return "\(outcome)"
+        default:
+            return "(\(outcome), \(successfulness))"
+        }
+    }
+    
+}
+
+// MARK: - CustomPlaygroundQuickLookable
+
+extension OutcomeWithSuccessfulness: CustomPlaygroundQuickLookable {
+    
+    public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
+        return PlaygroundQuickLook.Int(Int64(outcome))
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == (lhs: OutcomeWithSuccessfulness, rhs: OutcomeWithSuccessfulness) -> Bool {
+    return lhs.outcome == rhs.outcome && lhs.successfulness == rhs.successfulness
+}
+
+// MARK: - Comparable
+
+public func < (lhs: OutcomeWithSuccessfulness, rhs: OutcomeWithSuccessfulness) -> Bool {
+    if lhs.outcome == rhs.outcome {
+        return lhs.successfulness < rhs.successfulness
+    } else {
+        return lhs.outcome < rhs.outcome
+    }
+}
+
+// MARK: - FrequencyDistributionOutcomeType
+
+extension OutcomeWithSuccessfulness: FrequencyDistributionOutcomeType, IntegerArithmeticType {
+    
+    // MARK: FrequencyDistributionValueType
+    
+    public static let additiveIdentity = OutcomeWithSuccessfulness(Int.additiveIdentity)
+    public static let multiplicativeIdentity = OutcomeWithSuccessfulness(Int.multiplicativeIdentity)
+    public var multiplierEquivalent: Int {
+        return outcome
+    }
+    
+    // MARK: IntegerLiteralConvertible
+    
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+    
+    // MARK: Hashable
+    
+    public var hashValue: Int {
+        return "\(outcome.hashValue),\(successfulness.hashValue)".hashValue
+    }
+
+    // MARK: ForwardIndexType
+
+    public func successor() -> OutcomeWithSuccessfulness {
+        let successfulnessSuccessor = successfulness.successor()
+        if successfulnessSuccessor == .endIndex {
+            return OutcomeWithSuccessfulness(outcome + 1, .startIndex)
+        } else {
+            return OutcomeWithSuccessfulness(outcome, successfulnessSuccessor)
+        }
+    }
+    
+    // MARK: IntegerArithmeticType
+    
+    public static func addWithOverflow(lhs: OutcomeWithSuccessfulness, _ rhs: OutcomeWithSuccessfulness) -> (OutcomeWithSuccessfulness, overflow: Bool) {
+        let (outcome, overflow) = Int.addWithOverflow(lhs.outcome, rhs.outcome)
+        let successfulness = lhs.successfulness + rhs.successfulness
+        return (OutcomeWithSuccessfulness(outcome, successfulness), overflow: overflow)
+    }
+    
+    public static func subtractWithOverflow(lhs: OutcomeWithSuccessfulness, _ rhs: OutcomeWithSuccessfulness) -> (OutcomeWithSuccessfulness, overflow: Bool) {
+        let (outcome, overflow) = Int.subtractWithOverflow(lhs.outcome, rhs.outcome)
+        let successfulness = lhs.successfulness - rhs.successfulness
+        return (OutcomeWithSuccessfulness(outcome, successfulness), overflow: overflow)
+    }
+    
+    public static func multiplyWithOverflow(lhs: OutcomeWithSuccessfulness, _ rhs: OutcomeWithSuccessfulness) -> (OutcomeWithSuccessfulness, overflow: Bool) {
+        let (outcome, overflow) = Int.multiplyWithOverflow(lhs.outcome, rhs.outcome)
+        let successfulness = lhs.successfulness * rhs.successfulness
+        return (OutcomeWithSuccessfulness(outcome, successfulness), overflow: overflow)
+    }
+    
+    public static func divideWithOverflow(lhs: OutcomeWithSuccessfulness, _ rhs: OutcomeWithSuccessfulness) -> (OutcomeWithSuccessfulness, overflow: Bool) {
+        let (outcome, overflow) = Int.divideWithOverflow(lhs.outcome, rhs.outcome)
+        let successfulness = lhs.successfulness / rhs.successfulness
+        return (OutcomeWithSuccessfulness(outcome, successfulness), overflow: overflow)
+    }
+    
+    public static func remainderWithOverflow(lhs: OutcomeWithSuccessfulness, _ rhs: OutcomeWithSuccessfulness) -> (OutcomeWithSuccessfulness, overflow: Bool) {
+        let (outcome, overflow) = Int.remainderWithOverflow(lhs.outcome, rhs.outcome)
+        let successfulness = lhs.successfulness % rhs.successfulness
+        return (OutcomeWithSuccessfulness(outcome, successfulness), overflow: overflow)
+    }
+    
+    public func toIntMax() -> IntMax {
+        return outcome.toIntMax()
+    }
+    
+}

--- a/DiceKit/ProbabilisticExpressionType.swift
+++ b/DiceKit/ProbabilisticExpressionType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public typealias ExpressionProbabilityMass = ProbabilityMass<Int>
+public typealias ExpressionProbabilityMass = ProbabilityMass<OutcomeWithSuccessfulness>
 
 public protocol ProbabilisticExpressionType {
     

--- a/DiceKit/ProbabilityMass.swift
+++ b/DiceKit/ProbabilityMass.swift
@@ -95,6 +95,36 @@ extension ProbabilityMass: CollectionType {
     // Protocol defaults cover implmentation after conforming to `Indexable`
 }
 
+// MARK: - OutcomeWithSuccessfulnessType
+
+extension ProbabilityMass where OutcomeType: OutcomeWithSuccessfulnessType {
+    
+    public subscript(outcomeWithSuccessfulness outcome: Outcome) -> Probability? {
+        get {
+            return frequencyDistribution[outcomeWithSuccessfulness: outcome]
+        }
+    }
+    
+    public func valuesWithoutSuccessfulness() -> ProbabilityMass<Int> {
+        return ProbabilityMass<Int>(frequencyDistribution.valuesWithoutSuccessfulness(), normalize: false)
+    }
+    
+    public func successfulnessWithoutValues() -> ProbabilityMass<Successfulness> {
+        return ProbabilityMass<Successfulness>(frequencyDistribution.successfulnessWithoutValues())
+    }
+    
+    public func mapSuccessfulness(@noescape transform: (Outcome) -> Successfulness) -> ProbabilityMass {
+        let freqDist = frequencyDistribution.mapSuccessfulness(transform)
+        return ProbabilityMass(freqDist, normalize: false)
+    }
+    
+    public func setSuccessfulness(successfulness: Successfulness, comparedWith x: ProbabilityMass, @noescape passingComparison comparison: (Outcome, Outcome) -> Bool) -> ProbabilityMass {
+        let freqDist = frequencyDistribution.setSuccessfulness(successfulness, comparedWith: x.frequencyDistribution, passingComparison: comparison)
+        return ProbabilityMass(freqDist, normalize: false)
+    }
+    
+}
+
 // MARK: - Operations
 
 extension ProbabilityMass {

--- a/DiceKit/SubtractionExpressionResult.swift
+++ b/DiceKit/SubtractionExpressionResult.swift
@@ -53,6 +53,10 @@ extension SubtractionExpressionResult: ExpressionResultType {
     public var value: Int {
         return minuendResult.value - subtrahendResult.value
     }
+
+    public var successfulness: Successfulness {
+        return minuendResult.successfulness - subtrahendResult.successfulness
+    }
     
 }
 

--- a/DiceKit/Successfulness.swift
+++ b/DiceKit/Successfulness.swift
@@ -1,0 +1,140 @@
+//
+//  Successfulness.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/2/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+public enum Successfulness: Int, Comparable {
+    case Fail = -1
+    case Undetermined = 0
+    case Success = 1
+
+    /// Used to represent past the last value for ForwardIndexType.
+    /// - Warning: Don't use this value, as it will not produce valid results.
+    case Invalid
+
+    public static let startIndex = Successfulness.Fail
+    public static let endIndex = Successfulness.Invalid
+    
+    public static func combineSuccessfulnesses<C: CollectionType where C.Generator.Element == Successfulness>(successes: C) -> Successfulness {
+        guard successes.count > 0 else {
+            return .Undetermined
+        }
+        
+        let hasSuccess = successes.indexOf(.Success) != nil
+        let hasFail = successes.indexOf(.Fail) != nil
+        
+        switch (hasSuccess, hasFail) {
+        case (true, true), (false, false):
+            return .Undetermined
+        case (true, false):
+            return .Success
+        case (false, true):
+            return .Fail
+        }
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension Successfulness: CustomStringConvertible {
+    
+    public var description: String {
+        switch self {
+        case .Undetermined:
+            return "Undetermined"
+        case .Success:
+            return "Success"
+        case .Fail:
+            return "Fail"
+
+        case .Invalid:
+            return "Invalid"
+        }
+    }
+    
+}
+
+// MARK: - CustomPlaygroundQuickLookable
+
+extension Successfulness: CustomPlaygroundQuickLookable {
+    
+    public func customPlaygroundQuickLook() -> PlaygroundQuickLook {
+        return PlaygroundQuickLook.Int(Int64(rawValue))
+    }
+    
+}
+
+// MARK: - Comparable
+
+public func < (lhs: Successfulness, rhs: Successfulness) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
+
+// MARK: - FrequencyDistributionOutcomeType
+
+extension Successfulness: FrequencyDistributionOutcomeType {
+    
+    // MARK: FrequencyDistributionValueType
+    
+    public static let additiveIdentity = Successfulness.Undetermined
+    public static let multiplicativeIdentity = Successfulness.Success
+    public var multiplierEquivalent: Int {
+        return rawValue
+    }
+    
+    // MARK: IntegerLiteralConvertible
+    
+    public init(integerLiteral value: Int) {
+        let normalizedValue: Int
+        if (value > 0) {
+            normalizedValue = 1
+        } else if (value < 0) {
+            normalizedValue = -1
+        } else {
+            normalizedValue = 0
+        }
+        
+        self = Successfulness(rawValue: normalizedValue)!
+    }
+
+    // MARK: ForwardIndexType
+
+    public func successor() -> Successfulness {
+        guard self != Successfulness.endIndex else {
+            return Successfulness.endIndex
+        }
+
+        return Successfulness(rawValue: rawValue + 1)!
+    }
+    
+}
+
+// MARK: - ArithmeticType
+
+public func + (lhs: Successfulness, rhs: Successfulness) -> Successfulness {
+    let rawValue = lhs.rawValue + rhs.rawValue
+    return Successfulness(integerLiteral: rawValue)
+}
+
+public func - (lhs: Successfulness, rhs: Successfulness) -> Successfulness {
+    let rawValue = lhs.rawValue - rhs.rawValue
+    return Successfulness(integerLiteral: rawValue)
+}
+
+public func * (lhs: Successfulness, rhs: Successfulness) -> Successfulness {
+    let rawValue = lhs.rawValue * rhs.rawValue
+    return Successfulness(integerLiteral: rawValue)
+}
+
+public func / (lhs: Successfulness, rhs: Successfulness) -> Successfulness {
+    let rawValue = lhs.rawValue / rhs.rawValue
+    return Successfulness(integerLiteral: rawValue)
+}
+
+public func % (lhs: Successfulness, rhs: Successfulness) -> Successfulness {
+    let rawValue = lhs.rawValue % rhs.rawValue
+    return Successfulness(integerLiteral: rawValue)
+}

--- a/DiceKit/SuccessfulnessExpression.Comparison.Operation.swift
+++ b/DiceKit/SuccessfulnessExpression.Comparison.Operation.swift
@@ -1,0 +1,36 @@
+//
+//  SuccessfulnessExpression.Comparison.Operation.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/6/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+// Only not nested in `SuccessfulnessExpressionComparison` because its generic
+public enum SuccessfulnessExpressionComparisonOperation {
+    public typealias Closure = (Int, Int) -> Bool
+    
+    case Equal
+    case NotEqual
+    case LessThan
+    case LessThanOrEqual
+    case GreaterThan
+    case GreaterThanOrEqual
+    
+    public var closure: Closure {
+        switch self {
+        case .Equal:
+            return { $0 == $1 }
+        case .NotEqual:
+            return { $0 != $1 }
+        case .LessThan:
+            return { $0 < $1 }
+        case .LessThanOrEqual:
+            return { $0 <= $1 }
+        case .GreaterThan:
+            return { $0 > $1 }
+        case .GreaterThanOrEqual:
+            return { $0 >= $1 }
+        }
+    }
+}

--- a/DiceKit/SuccessfulnessExpression.Comparison.swift
+++ b/DiceKit/SuccessfulnessExpression.Comparison.swift
@@ -1,0 +1,27 @@
+//
+//  SuccessfulnessExpression.Comparison.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/6/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+// Only not nested in `SuccessfulnessExpression` because its generic
+public struct SuccessfulnessExpressionComparison<ComparisonExpression: protocol<ExpressionType, Equatable>>: Equatable {
+    
+    public let operation: SuccessfulnessExpressionComparisonOperation
+    public let comparedWith: ComparisonExpression
+    
+    public init(_ operation: SuccessfulnessExpressionComparisonOperation, _ comparedWith: ComparisonExpression) {
+        self.operation = operation
+        self.comparedWith = comparedWith
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == <C>(lhs: SuccessfulnessExpressionComparison<C>, rhs: SuccessfulnessExpressionComparison<C>) -> Bool {
+    return lhs.operation == rhs.operation
+        && lhs.comparedWith == rhs.comparedWith
+}

--- a/DiceKit/SuccessfulnessExpression.swift
+++ b/DiceKit/SuccessfulnessExpression.swift
@@ -1,0 +1,77 @@
+//
+//  SuccessfulnessExpression.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/2/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+public struct SuccessfulnessExpression<BaseExpression: protocol<ExpressionType, Equatable>, ComparisonExpression: protocol<ExpressionType, Equatable>>: Equatable {
+    
+    public typealias Comparison = SuccessfulnessExpressionComparison<ComparisonExpression>
+    
+    public let base: BaseExpression
+    
+    public let successComparison: Comparison?
+    public let failComparison: Comparison?
+    
+    public init(_ base: BaseExpression, successComparison: Comparison?, failComparison: Comparison?) {
+        self.base = base
+        self.successComparison = successComparison
+        self.failComparison = failComparison
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == <B, C>(lhs: SuccessfulnessExpression<B, C>, rhs: SuccessfulnessExpression<B, C>) -> Bool {
+    return lhs.base == rhs.base
+        && lhs.successComparison == rhs.successComparison
+        && lhs.failComparison == rhs.failComparison
+}
+
+// MARK: - ExpressionType
+
+extension SuccessfulnessExpression: ExpressionType {
+    
+    public typealias Result = SuccessfulnessExpressionResult<BaseExpression.Result, ComparisonExpression.Result>
+    
+    public func evaluate() -> Result {
+        let successComparisonResult = successComparison.flatMap {
+            Result.Comparison($0.operation, $0.comparedWith.evaluate())
+        }
+        let failComparisonResult = failComparison.flatMap {
+            Result.Comparison($0.operation, $0.comparedWith.evaluate())
+        }
+        return Result(base.evaluate(), successComparison: successComparisonResult, failComparison: failComparisonResult)
+    }
+    
+    private typealias ComparisonClosure = (ExpressionProbabilityMass.Outcome, ExpressionProbabilityMass.Outcome) -> Bool
+    
+    private func compareOnlyUndetermined(@noescape comparison: SuccessfulnessExpressionComparisonOperation.Closure)(_ lhs: ExpressionProbabilityMass.Outcome, _ rhs: ExpressionProbabilityMass.Outcome) -> Bool {
+        guard lhs.successfulness == .Undetermined else {
+            return false
+        }
+        
+        return comparison(lhs.outcome, rhs.outcome)
+    }
+    
+    public var probabilityMass: ExpressionProbabilityMass {
+        // Collect success or fail mappings
+        var mappings: [(successfulness: Successfulness, comparisonClosure: ComparisonClosure, comparedWith: ExpressionProbabilityMass)] = []
+        if let successComparison = successComparison {
+            mappings.append( (.Success, compareOnlyUndetermined(successComparison.operation.closure), successComparison.comparedWith.probabilityMass) )
+        }
+        if let failComparison = failComparison {
+            mappings.append( (.Fail, compareOnlyUndetermined(failComparison.operation.closure), failComparison.comparedWith.probabilityMass) )
+        }
+        
+        let probMass = mappings.reduce(base.probabilityMass) { (acc, mapping) -> ExpressionProbabilityMass in
+            acc.setSuccessfulness(mapping.successfulness, comparedWith: mapping.comparedWith, passingComparison: mapping.comparisonClosure)
+        }
+        
+        return probMass
+    }
+    
+}

--- a/DiceKit/SuccessfulnessExpressionResult.Comparison.swift
+++ b/DiceKit/SuccessfulnessExpressionResult.Comparison.swift
@@ -1,0 +1,27 @@
+//
+//  SuccessfulnessExpressionResult.Comparison.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/7/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+// Only not nested in `SuccessfulnessExpressionResult` because its generic
+public struct SuccessfulnessExpressionResultComparison<ComparisonResult: protocol<ExpressionResultType, Equatable>>: Equatable {
+    
+    public let operation: SuccessfulnessExpressionComparisonOperation
+    public let comparedWith: ComparisonResult
+    
+    public init(_ operation: SuccessfulnessExpressionComparisonOperation, _ comparedWith: ComparisonResult) {
+        self.operation = operation
+        self.comparedWith = comparedWith
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == <C>(lhs: SuccessfulnessExpressionResultComparison<C>, rhs: SuccessfulnessExpressionResultComparison<C>) -> Bool {
+    return lhs.operation == rhs.operation
+        && lhs.comparedWith == rhs.comparedWith
+}

--- a/DiceKit/SuccessfulnessExpressionResult.swift
+++ b/DiceKit/SuccessfulnessExpressionResult.swift
@@ -1,0 +1,62 @@
+//
+//  SuccessfulnessExpressionResult.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/2/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+public struct SuccessfulnessExpressionResult<BaseResult: protocol<ExpressionResultType, Equatable>, ComparisonResult: protocol<ExpressionResultType, Equatable>>: Equatable {
+    
+    public typealias Comparison = SuccessfulnessExpressionResultComparison<ComparisonResult>
+    
+    public let base: BaseResult
+    
+    public let successComparison: Comparison?
+    public let failComparison: Comparison?
+    
+    public init(_ base: BaseResult, successComparison: Comparison?, failComparison: Comparison?) {
+        self.base = base
+        self.successComparison = successComparison
+        self.failComparison = failComparison
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == <B, C>(lhs: SuccessfulnessExpressionResult<B, C>, rhs: SuccessfulnessExpressionResult<B, C>) -> Bool {
+    return lhs.base == rhs.base
+        && lhs.successComparison?.operation == rhs.successComparison?.operation
+        && lhs.successComparison?.comparedWith == rhs.successComparison?.comparedWith
+        && lhs.failComparison?.operation == rhs.failComparison?.operation
+        && lhs.failComparison?.comparedWith == rhs.failComparison?.comparedWith
+}
+
+// MARK: - ExpressionResultType
+
+extension SuccessfulnessExpressionResult: ExpressionResultType {
+    
+    public var value: Int {
+        return base.value
+    }
+    
+    public var successfulness: Successfulness {
+        let baseSuccessfulness = base .successfulness
+        guard baseSuccessfulness == .Undetermined else {
+            return baseSuccessfulness
+        }
+        
+        let computedValue = value
+        
+        if let s = successComparison where s.operation.closure(computedValue, s.comparedWith.value) {
+            return .Success
+        }
+        if let f = failComparison where f.operation.closure(computedValue, f.comparedWith.value) {
+            return .Fail
+        }
+        
+        return .Undetermined
+    }
+    
+}

--- a/DiceKit/SuccessfulnessResultType.swift
+++ b/DiceKit/SuccessfulnessResultType.swift
@@ -1,0 +1,13 @@
+//
+//  SuccessfulnessResultType.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/2/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+public protocol SuccessfulnessResultType {
+    
+    var successfulness: Successfulness { get }
+    
+}

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -79,6 +79,29 @@ extension AdditionExpressionResult_Tests {
         }
     }
     
+    func test_successfulness_shouldAddSuccessfulnesses() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                // Arrange
+                let expectedSuccessfulness = lhsSuccessfulness + rhsSuccessfulness // Tested already, so can use
+                
+                let lhsMock = MockExpressionResult()
+                lhsMock.stubSuccessfulness = lhsSuccessfulness
+                let rhsMock = MockExpressionResult()
+                rhsMock.stubSuccessfulness = rhsSuccessfulness
+                
+                let result = AdditionExpressionResult(lhsMock, rhsMock)
+                
+                // Act
+                let successfulness = result.successfulness
+                
+                // Assert
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
+    
 }
 
 // MARK: - CustomDebugStringConvertible

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -17,6 +17,13 @@ class AdditionExpression_Tests: XCTestCase {
     
 }
 
+// MARK: - Initialization
+extension AdditionExpression_Tests {
+    
+    // TODO: init
+    
+}
+
 // MARK: - Equatable
 extension AdditionExpression_Tests {
     

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -94,3 +94,37 @@ public struct FrequencyDistributionOf<Outcome : protocol<FrequencyDistributionOu
         return FrequencyDistribution<Outcome>.shrink(bl.getFrequencyDistribution).map(FrequencyDistributionOf.init)
     }
 }
+
+extension Successfulness: Arbitrary {
+    
+    public static func create(x : Int) -> Successfulness {
+        switch abs(x) % 3 {
+        case 0:
+            return .Undetermined
+        case 1:
+            return .Success
+        case 2:
+            return .Fail
+            
+        default: // Not possible
+            return .Undetermined
+        }
+    }
+    
+    public static var arbitrary : Gen<Successfulness> {
+        return Successfulness.create <^> Int.arbitrary.resize(3)
+    }
+    
+}
+
+extension OutcomeWithSuccessfulness: Arbitrary {
+    
+    public static func create(outcome : Int)(successfulness: Successfulness) -> OutcomeWithSuccessfulness {
+        return OutcomeWithSuccessfulness(outcome, successfulness)
+    }
+    
+    public static var arbitrary : Gen<OutcomeWithSuccessfulness> {
+        return OutcomeWithSuccessfulness.create <^> Int.arbitrary <*> Successfulness.arbitrary
+    }
+    
+}

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -117,6 +117,34 @@ extension Successfulness: Arbitrary {
     
 }
 
+extension SuccessfulnessExpressionComparisonOperation: Arbitrary {
+    
+    public static func create(x : Int) -> SuccessfulnessExpressionComparisonOperation {
+        switch abs(x) % 6 {
+        case 0:
+            return .Equal
+        case 1:
+            return .NotEqual
+        case 2:
+            return .GreaterThan
+        case 3:
+            return .GreaterThanOrEqual
+        case 4:
+            return .LessThan
+        case 5:
+            return .LessThanOrEqual
+            
+        default: // Not possible
+            return .Equal
+        }
+    }
+    
+    public static var arbitrary : Gen<SuccessfulnessExpressionComparisonOperation> {
+        return SuccessfulnessExpressionComparisonOperation.create <^> Int.arbitrary.resize(6)
+    }
+    
+}
+
 extension OutcomeWithSuccessfulness: Arbitrary {
     
     public static func create(outcome : Int)(successfulness: Successfulness) -> OutcomeWithSuccessfulness {

--- a/DiceKitTests/Constant_Tests.swift
+++ b/DiceKitTests/Constant_Tests.swift
@@ -81,6 +81,26 @@ extension Constant_Tests {
         }
     }
     
+//    func test_equatable() {
+//        property("equtatable") <- forAll {
+//            (a: Int, b: Int) in
+//            
+//            let reflexive = EquatableTestUtilities.checkReflexive { Constant(a) } <?> "reflexive"
+//            let symmetric = EquatableTestUtilities.checkSymmetric { Constant(a) } <?> "symmetric"
+//            let transitive = EquatableTestUtilities.checkTransitive { Constant(a) } <?> "transitive"
+//            let notEquate = (a != b) ==> {
+//                EquatableTestUtilities.checkNotEquate(
+//                    { Constant(a) },
+//                    { arc4random() % 2 == 1 ? Constant(b) : Constant(a) }
+//                )
+//            }() <?> "not-equate"
+//            
+//            return reflexive.whenFail { print("reflexive fail") } ^&&^ symmetric.whenFail { print("symmetric fail") } ^&&^ transitive.whenFail { print("transitive fail") } ^&&^ notEquate.withCallback(Callback.AfterFinalFailure(kind: .NotCounterexample, f: { (st, res) in
+//                print(res.stamp)
+//            }))
+//        }
+//    }
+    
 }
 
 // MARK: - ExpressionResultType

--- a/DiceKitTests/Constant_Tests.swift
+++ b/DiceKitTests/Constant_Tests.swift
@@ -82,3 +82,14 @@ extension Constant_Tests {
     }
     
 }
+
+// MARK: - ExpressionResultType
+extension Constant_Tests {
+    
+    func test_successfulness_shouldBeUndetermined() {
+        let constant = c(84)
+        
+        expect(constant.successfulness) == Successfulness.Undetermined
+    }
+    
+}

--- a/DiceKitTests/Die.Roll_Tests.swift
+++ b/DiceKitTests/Die.Roll_Tests.swift
@@ -95,3 +95,17 @@ extension Die_Roll_Tests {
     }
     
 }
+
+// MARK: - ExpressionResultType
+extension Die_Roll_Tests {
+    
+    func test_successfulness_shouldBeUndetermined() {
+        let expectedSuccessfulness = Successfulness.Undetermined
+        let dieRoll = Die.arbitrary.generate.evaluate()
+        
+        let successfulness = dieRoll.successfulness
+        
+        expect(successfulness) == expectedSuccessfulness
+    }
+    
+}

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -486,7 +486,7 @@ extension Die_Tests {
     
     func test_die_negativeSidedProbabilityMass() {
         let die = d(-2)
-        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution([-2: 0.5, -1: 0.5]))
+        let expectedProbabilityMass = ExpressionProbabilityMass(FrequencyDistribution([-2: 0.5, -1: 0.5]))
         
         expect(die.probabilityMass) == expectedProbabilityMass
     }

--- a/DiceKitTests/MockExpression.swift
+++ b/DiceKitTests/MockExpression.swift
@@ -31,9 +31,14 @@ class MockExpression: ExpressionType, Equatable {
 class MockExpressionResult: ExpressionResultType, Equatable {
     
     var stubValue: Int = 0
+    var stubSuccessfulness: Successfulness = .Undetermined
     
     var value: Int {
         return stubValue
+    }
+    
+    var successfulness: Successfulness {
+        return stubSuccessfulness
     }
     
 }

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -120,6 +120,32 @@ extension MultiplicationExpressionResult_Tests {
         }
     }
     
+    func test_successfulness_shouldCombineSuccessfulnesses() {
+        property("combine successfulness") <- forAll {
+            (sign: Bool, a: ArrayOf<Successfulness>) in
+            
+            let a = a.getArray
+            
+            // Arrange
+            let expectedSuccessfulness = Successfulness.combineSuccessfulnesses(a) // Tested already, so can use
+            
+            let multiplierResult = (sign ? 1 : -1) * a.count
+            let mockResults: [MockExpressionResult] = a.map {
+                let mockResult = MockExpressionResult()
+                mockResult.stubSuccessfulness = $0
+                return mockResult
+            }
+            
+            let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: mockResults)
+            
+            // Act
+            let successfulness = result.successfulness
+            
+            // Assert
+            return successfulness == expectedSuccessfulness
+        }
+    }
+    
 }
 
 // MARK: - CustomDebugStringConvertible

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -17,6 +17,13 @@ class MultiplicationExpression_Tests: XCTestCase {
     
 }
 
+// MARK: - Initialization
+extension MultiplicationExpression_Tests {
+    
+    // TODO: init
+    
+}
+
 // MARK: - Equatable
 extension MultiplicationExpression_Tests {
     

--- a/DiceKitTests/NegationExpressionResult_Tests.swift
+++ b/DiceKitTests/NegationExpressionResult_Tests.swift
@@ -75,6 +75,23 @@ extension NegationExpressionResult_Tests {
         }
     }
     
+    func test_successfulness_shouldPassThroughBaseResult() {
+        let possibleSuccessfulnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        // TODO: Change to `forEach` in Beta 5
+        possibleSuccessfulnesses.map {
+            (successfulness: Successfulness) -> Void in
+            
+            let expectedSuccessfulness = successfulness
+            let mockExpressionResult = MockExpressionResult()
+            mockExpressionResult.stubSuccessfulness = expectedSuccessfulness
+            let result = NegationExpressionResult(mockExpressionResult)
+            
+            let successfulness = result.successfulness
+            
+            expect(successfulness) == expectedSuccessfulness
+        }
+    }
+    
 }
 
 // MARK: - CustomDebugStringConvertible

--- a/DiceKitTests/NegationExpression_Tests.swift
+++ b/DiceKitTests/NegationExpression_Tests.swift
@@ -17,6 +17,13 @@ class NegationExpression_Tests: XCTestCase {
     
 }
 
+// MARK: - Initialization
+extension NegationExpression_Tests {
+    
+    // TODO: init
+    
+}
+
 // MARK: - Equatable
 extension NegationExpression_Tests {
     

--- a/DiceKitTests/OutcomeWithSuccessfulness_Tests.swift
+++ b/DiceKitTests/OutcomeWithSuccessfulness_Tests.swift
@@ -1,0 +1,245 @@
+//
+//  OutcomeWithSuccessfulness_Tests.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/8/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+class OutcomeWithSuccessfulness_Tests: XCTestCase {
+    
+}
+
+// MARK: - Initialization
+extension OutcomeWithSuccessfulness_Tests {
+    
+    func test_init() {
+        let expectedOutcome = 57
+        let expectedSuccessfulness = Successfulness.Fail
+        
+        let outcomeWithSuccessfulness = OutcomeWithSuccessfulness(expectedOutcome, expectedSuccessfulness)
+        
+        expect(outcomeWithSuccessfulness.outcome) == expectedOutcome
+        expect(outcomeWithSuccessfulness.successfulness) == expectedSuccessfulness
+    }
+    
+    func test_init_shouldDefaultSuccessfulnessToUndecided() {
+        let outcomeWithSuccessfulness = OutcomeWithSuccessfulness(57)
+        
+        expect(outcomeWithSuccessfulness.successfulness) == Successfulness.Undetermined
+    }
+    
+    func test_init_shouldBeIntegerLiteralConvertible() {
+        let zeroLiteral: OutcomeWithSuccessfulness = 0
+        let otherLiteral: OutcomeWithSuccessfulness = 564
+        
+        expect(zeroLiteral) == OutcomeWithSuccessfulness(0)
+        expect(otherLiteral) == OutcomeWithSuccessfulness(564)
+    }
+    
+}
+
+// MARK: - Equatable
+extension OutcomeWithSuccessfulness_Tests {
+    
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (i: Int, s: Successfulness) in
+            
+            return EquatableTestUtilities.checkReflexive { OutcomeWithSuccessfulness(i, s) }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (i: Int, s: Successfulness) in
+            
+            return EquatableTestUtilities.checkSymmetric { OutcomeWithSuccessfulness(i, s) }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (i: Int, s: Successfulness) in
+            
+            return EquatableTestUtilities.checkTransitive { OutcomeWithSuccessfulness(i, s) }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (i: Int, j: Int, s1: Successfulness, s2: Successfulness) in
+            
+            return (i != j && s1 != s2) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { OutcomeWithSuccessfulness(i, s1) },
+                    { OutcomeWithSuccessfulness(j, s2) }
+                )
+            }
+        }
+    }
+    
+}
+
+// MARK: - CustomPlaygroundQuickLookable
+extension OutcomeWithSuccessfulness_Tests {
+    
+    func test_customPlaygroundQuickLook() {
+        let s = OutcomeWithSuccessfulness(58, .Success)
+        
+        switch s.customPlaygroundQuickLook() {
+        case let PlaygroundQuickLook.Int(outcome):
+            expect(outcome) == Int64(s.outcome)
+        default:
+            fail()
+        }
+    }
+    
+}
+
+// MARK: - Comparable
+extension OutcomeWithSuccessfulness_Tests {
+    
+    func test_operator_lessThan() {
+        property("less than") <- forAll {
+            (a: OutcomeWithSuccessfulness, b: OutcomeWithSuccessfulness) in
+            
+            let expectedLessThan: Bool
+            if a.outcome == b.outcome {
+                expectedLessThan = a.successfulness < b.successfulness
+            } else {
+                expectedLessThan = a.outcome < b.outcome
+            }
+            
+            let lessThan = a < b
+            
+            return lessThan == expectedLessThan
+        }
+    }
+    
+}
+
+// MARK: - IntegerArithmeticType
+extension OutcomeWithSuccessfulness_Tests {
+    
+    func test_addWithOverflow() {
+        property("add") <- forAll {
+            (a: OutcomeWithSuccessfulness, b: OutcomeWithSuccessfulness) in
+            
+            let (expectedOutcome, expectedOverflow) = Int.addWithOverflow(a.outcome, b.outcome)
+            let expectedSuccessfulness = a.successfulness + b.successfulness
+            
+            let (outcome, overflow) = OutcomeWithSuccessfulness.addWithOverflow(a, b)
+            
+            let testOutcome = outcome.outcome == expectedOutcome
+            let testSuccessfulness = outcome.successfulness == expectedSuccessfulness
+            let testOverflow = overflow == expectedOverflow
+            
+            return testOutcome && testSuccessfulness && testOverflow
+        }
+    }
+    
+    func test_subtractWithOverflow() {
+        property("subtract") <- forAll {
+            (a: OutcomeWithSuccessfulness, b: OutcomeWithSuccessfulness) in
+            
+            let (expectedOutcome, expectedOverflow) = Int.subtractWithOverflow(a.outcome, b.outcome)
+            let expectedSuccessfulness = a.successfulness - b.successfulness
+            
+            let (outcome, overflow) = OutcomeWithSuccessfulness.subtractWithOverflow(a, b)
+            
+            let testOutcome = outcome.outcome == expectedOutcome
+            let testSuccessfulness = outcome.successfulness == expectedSuccessfulness
+            let testOverflow = overflow == expectedOverflow
+            
+            return testOutcome && testSuccessfulness && testOverflow
+        }
+    }
+    
+    func test_multiplyWithOverflow() {
+        property("multiply") <- forAll {
+            (a: OutcomeWithSuccessfulness, b: OutcomeWithSuccessfulness) in
+            
+            let (expectedOutcome, expectedOverflow) = Int.multiplyWithOverflow(a.outcome, b.outcome)
+            let expectedSuccessfulness = a.successfulness * b.successfulness
+            
+            let (outcome, overflow) = OutcomeWithSuccessfulness.multiplyWithOverflow(a, b)
+            
+            let testOutcome = outcome.outcome == expectedOutcome
+            let testSuccessfulness = outcome.successfulness == expectedSuccessfulness
+            let testOverflow = overflow == expectedOverflow
+            
+            return testOutcome && testSuccessfulness && testOverflow
+        }
+    }
+    
+    func test_divideWithOverflow() {
+        property("divide") <- forAll {
+            (a: OutcomeWithSuccessfulness, b: OutcomeWithSuccessfulness) in
+            
+            return (b.outcome != 0 && b.successfulness != .Undetermined) ==> {
+                let (expectedOutcome, expectedOverflow) = Int.divideWithOverflow(a.outcome, b.outcome)
+                let expectedSuccessfulness = a.successfulness / b.successfulness
+                
+                let (outcome, overflow) = OutcomeWithSuccessfulness.divideWithOverflow(a, b)
+                
+                let testOutcome = outcome.outcome == expectedOutcome
+                let testSuccessfulness = outcome.successfulness == expectedSuccessfulness
+                let testOverflow = overflow == expectedOverflow
+                
+                return testOutcome && testSuccessfulness && testOverflow
+            }
+        }
+    }
+    
+    func test_remainderWithOverflow() {
+        property("remainder") <- forAll {
+            (a: OutcomeWithSuccessfulness, b: OutcomeWithSuccessfulness) in
+            
+            return (b.outcome != 0 && b.successfulness != .Undetermined) ==> {
+                let (expectedOutcome, expectedOverflow) = Int.remainderWithOverflow(a.outcome, b.outcome)
+                let expectedSuccessfulness = a.successfulness % b.successfulness
+                
+                let (outcome, overflow) = OutcomeWithSuccessfulness.remainderWithOverflow(a, b)
+                
+                let testOutcome = outcome.outcome == expectedOutcome
+                let testSuccessfulness = outcome.successfulness == expectedSuccessfulness
+                let testOverflow = overflow == expectedOverflow
+                
+                return testOutcome && testSuccessfulness && testOverflow
+            }
+        }
+    }
+    
+    func test_toIntMax() {
+        let baseOutcome = 56
+        let outcomeWithSuccessfulness = OutcomeWithSuccessfulness(baseOutcome, .Fail)
+        let expectedOutcomeIntMax = IntMax(baseOutcome)
+        
+        let outcomeIntMax = outcomeWithSuccessfulness.toIntMax()
+        
+        expect(outcomeIntMax) == expectedOutcomeIntMax
+    }
+    
+}
+
+// MARK: - FrequencyDistributionValueType
+extension OutcomeWithSuccessfulness_Tests {
+    
+    func test_multiplicativeIdentity() {
+        expect(OutcomeWithSuccessfulness.multiplicativeIdentity) == OutcomeWithSuccessfulness(1)
+    }
+    
+    func test_multiplierEquivalent() {
+        let s = OutcomeWithSuccessfulness(84, .Fail)
+        
+        expect(s.multiplierEquivalent) == s.outcome
+    }
+    
+}

--- a/DiceKitTests/ProbabilityMass_Tests.swift
+++ b/DiceKitTests/ProbabilityMass_Tests.swift
@@ -172,6 +172,175 @@ extension ProbabilityMass_Tests {
     
 }
 
+// MARK: - OutcomeWithSuccessfulnessType
+extension ProbabilityMass_Tests {
+    
+    func test_subscript_outcomeWithSuccessfulness_shouldReturnDiscreteFrequencyForSuccessOrFail() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0, S(7, .Fail): 2.0, S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        let desiredOutcome = S(7, .Fail)
+        let expectedFrequency = 2.0/11.0
+        
+        let probability = probMass[outcomeWithSuccessfulness: desiredOutcome]
+        
+        expect(probability) == expectedFrequency
+    }
+    
+    func test_subscript_outcomeWithSuccessfulness_shouldReturnSummedFrequencyForUndetermined() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0, S(7, .Fail): 2.0, S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        let expectedProbability7 = 6.0/11.0
+        let expectedProbability5 = 1.5/11.0
+        let expectedProbability4 = 1.0/11.0
+        
+        let probability7 = probMass[outcomeWithSuccessfulness: S(7, .Undetermined)]
+        let probability5 = probMass[outcomeWithSuccessfulness: S(5, .Undetermined)]
+        let probability4 = probMass[outcomeWithSuccessfulness: S(4, .Undetermined)]
+        
+        expect(probability7) == expectedProbability7
+        expect(probability5) == expectedProbability5
+        expect(probability4) == expectedProbability4
+    }
+    
+    func test_subscript_outcomeWithSuccessfulness_shouldReturnNilForInvalidOutcome() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0, S(7, .Fail): 2.0, S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        
+        let probability = probMass[outcomeWithSuccessfulness: S(77, .Undetermined)]
+        
+        expect(probability).to(beNil())
+    }
+    
+    func test_valuesWithoutSuccessfulness() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0, S(7, .Fail): 2.0, S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            7: 6.0,
+            6: 2.5,
+            5: 1.5,
+            4: 1.0,
+        ]
+        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution(expectedFrequenciesPerOutcome))
+        
+        let valuesWithoutSuccessfulness = probMass.valuesWithoutSuccessfulness()
+        
+        expect(valuesWithoutSuccessfulness) == expectedProbabilityMass
+    }
+    
+    func test_successfulnessWithoutValues() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0,
+            S(7, .Fail): 2.0,
+            S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        let expectedFrequenciesPerOutcome: FrequencyDistribution<Successfulness>.FrequenciesPerOutcome = [
+            .Success: 4.0,
+            .Undetermined: 3.5,
+            .Fail: 3.5,
+        ]
+        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution(expectedFrequenciesPerOutcome))
+        
+        let successfulnessWithoutValues = probMass.successfulnessWithoutValues()
+        
+        expect(successfulnessWithoutValues) == expectedProbabilityMass
+    }
+    
+    func test_mapSuccessfulness() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0,
+            S(7, .Fail): 2.0,
+            S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        let map = { (outcome: S) -> Successfulness in
+            // If odd outcome, then .Fail, otherwise .Success
+            outcome.outcome % 2 == 1 ? .Fail : .Success
+        }
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Fail): 6.0,
+            S(6, .Success): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution(expectedFrequenciesPerOutcome))
+        
+        let mappedSuccessfulness = probMass.mapSuccessfulness(map)
+        
+        expect(mappedSuccessfulness) == expectedProbabilityMass
+    }
+    
+    func test_setSuccessfulness() {
+        typealias S = OutcomeWithSuccessfulness
+        
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Success): 3.0, S(7, .Fail): 2.0, S(7, .Undetermined): 1.0,
+            S(6, .Undetermined): 2.5,
+            S(5, .Fail): 1.5,
+            S(4, .Success): 1.0,
+        ]
+        let compareFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(1, .Success): 2.0,
+            S(2, .Fail): 0.5,
+        ]
+        let probMass = ProbabilityMass(FrequencyDistribution(frequenciesPerOutcome))
+        let compareProbMass = ProbabilityMass(FrequencyDistribution(compareFrequenciesPerOutcome))
+        let comparison = { (lhs: S, rhs: S) in
+            (lhs.outcome + rhs.outcome) % 2 == 0
+        }
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            S(7, .Fail): 13.0, S(7, .Success): 1.5, S(7, .Undetermined): 0.5,
+            S(6, .Fail): 1.25, S(6, .Undetermined): 5.0,
+            S(5, .Fail): 3.75,
+            S(4, .Success): 2.0, S(4, .Fail): 0.5,
+        ]
+        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution(expectedFrequenciesPerOutcome))
+        
+        let setSuccessfulness = probMass.setSuccessfulness(.Fail, comparedWith: compareProbMass, passingComparison: comparison)
+        
+        expect(setSuccessfulness ≈ expectedProbabilityMass) == true
+    }
+    
+}
+
 // MARK: - Operations
 extension ProbabilityMass_Tests {
     

--- a/DiceKitTests/SubtractionExpressionResult_Tests.swift
+++ b/DiceKitTests/SubtractionExpressionResult_Tests.swift
@@ -94,6 +94,29 @@ extension SubtractionExpressionResult_Tests {
             return value == expectedValue
         }
     }
+
+    func test_successfulness_shouldSubtractSuccessfulnesses() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                // Arrange
+                let expectedSuccessfulness = lhsSuccessfulness - rhsSuccessfulness // Tested already, so can use
+
+                let lhsMock = MockExpressionResult()
+                lhsMock.stubSuccessfulness = lhsSuccessfulness
+                let rhsMock = MockExpressionResult()
+                rhsMock.stubSuccessfulness = rhsSuccessfulness
+
+                let result = SubtractionExpressionResult(lhsMock, rhsMock)
+
+                // Act
+                let successfulness = result.successfulness
+
+                // Assert
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
     
 }
 

--- a/DiceKitTests/SuccessfulnessExpression.Comparison.Operation_Tests.swift
+++ b/DiceKitTests/SuccessfulnessExpression.Comparison.Operation_Tests.swift
@@ -1,0 +1,66 @@
+//
+//  SuccessfulnessExpression.Comparison.Operation_Tests.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/6/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+class SuccessfulnessExpression_Comparison_Operation_Tests: XCTestCase {
+
+    // Unit Under Test
+    typealias UUT = SuccessfulnessExpressionComparisonOperation
+    
+}
+
+// MARK: - Equatable
+extension SuccessfulnessExpression_Comparison_Operation_Tests {
+    
+    // TODO: Equatable
+    
+}
+
+// MARK: -
+extension SuccessfulnessExpression_Comparison_Operation_Tests {
+    
+    func test_closure_shouldEvaluateCorrectly() {
+        property("closure") <- forAll {
+            (a: Int, b: Int) in
+            
+            let expectedEqual = (a == b)
+            let expectedNotEqual = (a != b)
+            let expectedLessThan = (a < b)
+            let expectedLessThanOrEqual = (a <= b)
+            let expectedGreaterThan = (a > b)
+            let expectedGreaterThanOrEqual = (a >= b)
+            
+            let equal = UUT.Equal.closure(a, b)
+            let notEqual = UUT.NotEqual.closure(a, b)
+            let lessThan = UUT.LessThan.closure(a, b)
+            let lessThanOrEqual = UUT.LessThanOrEqual.closure(a, b)
+            let greaterThan = UUT.GreaterThan.closure(a, b)
+            let greaterThanOrEqual = UUT.GreaterThanOrEqual.closure(a, b)
+            
+            let testEqual = equal == expectedEqual
+            let testNotEqual = notEqual == expectedNotEqual
+            let testLessThan = lessThan == expectedLessThan
+            let testLessThanOrEqual = lessThanOrEqual == expectedLessThanOrEqual
+            let testGreaterThan = greaterThan == expectedGreaterThan
+            let testGreaterThanOrEqual = greaterThanOrEqual == expectedGreaterThanOrEqual
+            
+            return testEqual
+                && testNotEqual
+                && testLessThan
+                && testLessThanOrEqual
+                && testGreaterThan
+                && testGreaterThanOrEqual
+        }
+    }
+
+}

--- a/DiceKitTests/SuccessfulnessExpressionResult_Tests.swift
+++ b/DiceKitTests/SuccessfulnessExpressionResult_Tests.swift
@@ -1,0 +1,206 @@
+//
+//  SuccessfulnessExpressionResult_Tests.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/7/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+class SuccessfulnessExpressionResult_Tests: XCTestCase {
+    
+}
+
+// MARK: - Initialization
+extension SuccessfulnessExpressionResult_Tests {
+    
+    func test_init_shouldAllowBothComparisonsToBeNonNil() {
+        let expectedBaseExpression = c(1)
+        let successOperation = SuccessfulnessExpressionComparisonOperation.Equal
+        let failOperation = SuccessfulnessExpressionComparisonOperation.GreaterThan
+        let expectedSuccessComparison = SuccessfulnessExpressionResultComparison(successOperation, c(4))
+        let expectedFailComparison = SuccessfulnessExpressionResultComparison(failOperation, c(-8))
+        
+        let expression = SuccessfulnessExpressionResult(expectedBaseExpression, successComparison: expectedSuccessComparison, failComparison: expectedFailComparison)
+        
+        expect(expression.base) == expectedBaseExpression
+        expect(expression.successComparison) == expectedSuccessComparison
+        expect(expression.failComparison) == expectedFailComparison
+    }
+    
+    func test_init_shouldAllowSuccessComparisonToBeNil() {
+        let expectedBaseExpression = c(567)
+        let failOperation = SuccessfulnessExpressionComparisonOperation.LessThanOrEqual
+        let expectedFailComparison = SuccessfulnessExpressionResultComparison(failOperation, c(77))
+        
+        let expression = SuccessfulnessExpressionResult(expectedBaseExpression, successComparison: nil, failComparison: expectedFailComparison)
+        
+        expect(expression.base) == expectedBaseExpression
+        expect(expression.successComparison).to(beNil())
+        expect(expression.failComparison) == expectedFailComparison
+    }
+    
+    func test_init_shouldAllowFailComparisonToBeNil() {
+        let expectedBaseExpression = c(-7)
+        let successOperation = SuccessfulnessExpressionComparisonOperation.NotEqual
+        let expectedSuccessComparison = SuccessfulnessExpressionResultComparison(successOperation, c(8665))
+        
+        let expression = SuccessfulnessExpressionResult(expectedBaseExpression, successComparison: expectedSuccessComparison, failComparison: nil)
+        
+        expect(expression.base) == expectedBaseExpression
+        expect(expression.successComparison) == expectedSuccessComparison
+        expect(expression.failComparison).to(beNil())
+    }
+    
+}
+
+// MARK: - Equatable
+extension SuccessfulnessExpressionResult_Tests {
+    
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let successComparison = SuccessfulnessExpressionResultComparison(m, y)
+            let failComparison = SuccessfulnessExpressionResultComparison(n, z)
+            
+            return EquatableTestUtilities.checkReflexive {
+                SuccessfulnessExpressionResult(x, successComparison: successComparison, failComparison: failComparison)
+            }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let successComparison = SuccessfulnessExpressionResultComparison(m, y)
+            let failComparison = SuccessfulnessExpressionResultComparison(n, z)
+            
+            return EquatableTestUtilities.checkSymmetric {
+                SuccessfulnessExpressionResult(x, successComparison: successComparison, failComparison: failComparison)
+            }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let successComparison = SuccessfulnessExpressionResultComparison(m, y)
+            let failComparison = SuccessfulnessExpressionResultComparison(n, z)
+            
+            return EquatableTestUtilities.checkTransitive {
+                SuccessfulnessExpressionResult(x, successComparison: successComparison, failComparison: failComparison)
+            }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: Constant, b: Constant, c: Constant, d: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let comparison1 = SuccessfulnessExpressionResultComparison(m, c)
+            let comparison2 = SuccessfulnessExpressionResultComparison(n, d)
+            
+            return !(a == b && c == d) ==> {
+                return EquatableTestUtilities.checkNotEquate(
+                    { SuccessfulnessExpressionResult(a, successComparison: comparison1, failComparison: comparison2) },
+                    { SuccessfulnessExpressionResult(b, successComparison: comparison2, failComparison: comparison1) }
+                )
+            }
+        }
+    }
+    
+}
+
+// MARK: - ExpressionResultType
+extension SuccessfulnessExpressionResult_Tests {
+    
+    func test_value_shouldPassthrough() {
+        let baseResult = c(6)
+        let successComparisonResult = SuccessfulnessExpressionResultComparison(.NotEqual, c(-3))
+        let failComparisonResult = SuccessfulnessExpressionResultComparison(.GreaterThanOrEqual, c(7))
+        
+        let result = SuccessfulnessExpressionResult(baseResult, successComparison: successComparisonResult, failComparison: failComparisonResult)
+        
+        expect(result.value) == baseResult.value
+    }
+    
+    func test_successfulness_shouldUseSuccessFirst() {
+        let baseResult = c(8)
+        let successComparisonResult = SuccessfulnessExpressionResultComparison(.Equal, baseResult)
+        let failComparisonResult = SuccessfulnessExpressionResultComparison(.Equal, baseResult)
+        let expectedSuccessfulness = Successfulness.Success
+        
+        let result = SuccessfulnessExpressionResult(baseResult, successComparison: successComparisonResult, failComparison: failComparisonResult)
+        
+        expect(result.successfulness) == expectedSuccessfulness
+    }
+    
+    func test_successfulness_shouldUseSuccessEvenWhenNoFail() {
+        let baseResult = c(9)
+        let successComparisonResult = SuccessfulnessExpressionResultComparison(.Equal, baseResult)
+        let expectedSuccessfulness = Successfulness.Success
+        
+        let result = SuccessfulnessExpressionResult(baseResult, successComparison: successComparisonResult, failComparison: nil)
+        
+        expect(result.successfulness) == expectedSuccessfulness
+    }
+    
+    func test_successfulness_shouldUseFailEvenWhenNoSuccess() {
+        let baseResult = c(14)
+        let failComparisonResult = SuccessfulnessExpressionResultComparison(.Equal, baseResult)
+        let expectedSuccessfulness = Successfulness.Fail
+        let result = SuccessfulnessExpressionResult(baseResult, successComparison: nil, failComparison: failComparisonResult)
+        
+        let successfulness = result.successfulness
+        
+        expect(successfulness) == expectedSuccessfulness
+    }
+    
+    func test_successfulness_shouldPassThroughExistingSuccessOrFail() {
+        // Arrange
+        let expectedSuccessfulness = Successfulness.Success
+        
+        let baseResult = c(5)
+        let mockExpressionResult = MockExpressionResult()
+        mockExpressionResult.stubValue = baseResult.value
+        mockExpressionResult.stubSuccessfulness = expectedSuccessfulness
+        
+        let failComparisonResult = SuccessfulnessExpressionResultComparison(.Equal, baseResult)
+        let result = SuccessfulnessExpressionResult(mockExpressionResult, successComparison: nil, failComparison: failComparisonResult)
+        
+        // Act
+        let successfulness = result.successfulness
+        
+        // Assert
+        expect(successfulness) == expectedSuccessfulness
+    }
+    
+    func test_successfulness_shouldPassThroughWhenNeitherSuccessOrFail() {
+        // Arrange
+        let expectedSuccessfulness = Successfulness.Undetermined
+        
+        let baseResult = c(5)
+        let mockExpressionResult = MockExpressionResult()
+        mockExpressionResult.stubValue = baseResult.value
+        mockExpressionResult.stubSuccessfulness = expectedSuccessfulness
+        
+        let successComparisonResult = SuccessfulnessExpressionResultComparison(.LessThan, baseResult)
+        let failComparisonResult = SuccessfulnessExpressionResultComparison(.GreaterThan, baseResult)
+        let result = SuccessfulnessExpressionResult(mockExpressionResult, successComparison: successComparisonResult, failComparison: failComparisonResult)
+        
+        // Act
+        let successfulness = result.successfulness
+        
+        // Assert
+        expect(successfulness) == expectedSuccessfulness
+    }
+    
+}

--- a/DiceKitTests/SuccessfulnessExpression_Tests.swift
+++ b/DiceKitTests/SuccessfulnessExpression_Tests.swift
@@ -1,0 +1,183 @@
+//
+//  SuccessfulnessExpression_Tests.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/6/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+class SuccessfulnessExpression_Tests: XCTestCase {
+
+}
+
+// MARK: - Initialization
+extension SuccessfulnessExpression_Tests {
+    
+    func test_init_shouldAllowBothComparisonsToBeNonNil() {
+        let expectedBaseExpression = c(1)
+        let successOperation = SuccessfulnessExpressionComparisonOperation.Equal
+        let failOperation = SuccessfulnessExpressionComparisonOperation.GreaterThan
+        let expectedSuccessComparison = SuccessfulnessExpressionComparison(successOperation, c(4))
+        let expectedFailComparison = SuccessfulnessExpressionComparison(failOperation, c(-8))
+        
+        let expression = SuccessfulnessExpression(expectedBaseExpression, successComparison: expectedSuccessComparison, failComparison: expectedFailComparison)
+        
+        expect(expression.base) == expectedBaseExpression
+        expect(expression.successComparison) == expectedSuccessComparison
+        expect(expression.failComparison) == expectedFailComparison
+    }
+    
+    func test_init_shouldAllowSuccessComparisonsToBeNil() {
+        let expectedBaseExpression = c(567)
+        let failOperation = SuccessfulnessExpressionComparisonOperation.LessThanOrEqual
+        let expectedFailComparison = SuccessfulnessExpressionComparison(failOperation, c(77))
+        
+        let expression = SuccessfulnessExpression(expectedBaseExpression, successComparison: nil, failComparison: expectedFailComparison)
+        
+        expect(expression.base) == expectedBaseExpression
+        expect(expression.successComparison).to(beNil())
+        expect(expression.failComparison) == expectedFailComparison
+    }
+    
+    func test_init_shouldAllowFailComparisonsToBeNil() {
+        let expectedBaseExpression = c(-7)
+        let successOperation = SuccessfulnessExpressionComparisonOperation.NotEqual
+        let expectedSuccessComparison = SuccessfulnessExpressionComparison(successOperation, c(8665))
+        
+        let expression = SuccessfulnessExpression(expectedBaseExpression, successComparison: expectedSuccessComparison, failComparison: nil)
+        
+        expect(expression.base) == expectedBaseExpression
+        expect(expression.successComparison) == expectedSuccessComparison
+        expect(expression.failComparison).to(beNil())
+    }
+    
+}
+
+// MARK: - Equatable
+extension SuccessfulnessExpression_Tests {
+    
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let successComparison = SuccessfulnessExpressionComparison(m, y)
+            let failComparison = SuccessfulnessExpressionComparison(n, z)
+            
+            return EquatableTestUtilities.checkReflexive {
+                SuccessfulnessExpression(x, successComparison: successComparison, failComparison: failComparison)
+            }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let successComparison = SuccessfulnessExpressionComparison(m, y)
+            let failComparison = SuccessfulnessExpressionComparison(n, z)
+            
+            return EquatableTestUtilities.checkSymmetric {
+                SuccessfulnessExpression(x, successComparison: successComparison, failComparison: failComparison)
+            }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let successComparison = SuccessfulnessExpressionComparison(m, y)
+            let failComparison = SuccessfulnessExpressionComparison(n, z)
+            
+            return EquatableTestUtilities.checkTransitive {
+                SuccessfulnessExpression(x, successComparison: successComparison, failComparison: failComparison)
+            }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: Constant, b: Constant, c: Constant, d: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            let comparison1 = SuccessfulnessExpressionComparison(m, c)
+            let comparison2 = SuccessfulnessExpressionComparison(n, d)
+            
+            return !(a == b && c == d) ==> {
+                return EquatableTestUtilities.checkNotEquate(
+                    { SuccessfulnessExpression(a, successComparison: comparison1, failComparison: comparison2) },
+                    { SuccessfulnessExpression(b, successComparison: comparison2, failComparison: comparison1) }
+                )
+            }
+        }
+    }
+    
+}
+
+// MARK: - ExpressionType
+extension SuccessfulnessExpression_Tests {
+    
+    func test_evaluate_shouldCreateResultCorrectly() {
+        property("create results") <- forAll {
+            (x: Constant, y: Constant, z: Constant, m: SuccessfulnessExpressionComparisonOperation, n: SuccessfulnessExpressionComparisonOperation) in
+            
+            // Arrange
+            let expectedSuccessOperation = m
+            let expectedFailOperation = n
+            let successComparison = SuccessfulnessExpressionComparison(m, y)
+            let failComparison = SuccessfulnessExpressionComparison(n, z)
+            
+            let expression = SuccessfulnessExpression(x, successComparison: successComparison, failComparison: failComparison)
+            
+            // Act
+            let result = expression.evaluate()
+            
+            // Assert
+            let testBaseResult = result.base.value == x.value
+            let testSuccessComparisonResult = result.successComparison?.comparedWith.value == y.value
+            let testFailComparisonResult = result.failComparison?.comparedWith.value == z.value
+            let testSuccessComparisonResultOperation = result.successComparison?.operation == expectedSuccessOperation
+            let testFailComparisonResultOperation = result.failComparison?.operation == expectedFailOperation
+            
+            return testBaseResult
+                && testSuccessComparisonResult
+                && testFailComparisonResult
+                && testSuccessComparisonResultOperation
+                && testFailComparisonResultOperation
+        }
+    }
+    
+    func test_probabilityMass_shouldApplySuccessfulnessToUndetermined() {
+        let constantValue = 1
+        let succesfulness = Successfulness.Success
+        let baseProbabilityMass = ExpressionProbabilityMass(FrequencyDistribution([OutcomeWithSuccessfulness(constantValue, .Undetermined): 1.0]))
+        let expectedProbabilityMass = ExpressionProbabilityMass(FrequencyDistribution([OutcomeWithSuccessfulness(constantValue, succesfulness): 1.0]))
+        let mockBaseExpression = MockExpression()
+        mockBaseExpression.stubProbabilityMass = baseProbabilityMass
+        let expression = SuccessfulnessExpression(mockBaseExpression, successComparison: SuccessfulnessExpressionComparison(.Equal, c(constantValue)), failComparison: nil)
+        
+        let probabilityMass = expression.probabilityMass
+        
+        expect(probabilityMass) == expectedProbabilityMass
+    }
+    
+    func test_probabilityMass_shouldNotApplySuccessfulnessToNotUndetermined() {
+        let constantValue = 1
+        let succesfulness = Successfulness.Success
+        let baseProbabilityMass = ExpressionProbabilityMass(FrequencyDistribution([OutcomeWithSuccessfulness(constantValue, succesfulness): 1.0]))
+        let expectedProbabilityMass = baseProbabilityMass
+        let mockBaseExpression = MockExpression()
+        mockBaseExpression.stubProbabilityMass = baseProbabilityMass
+        let expression = SuccessfulnessExpression(mockBaseExpression, successComparison: nil, failComparison:  SuccessfulnessExpressionComparison(.Equal, c(constantValue)))
+        
+        let probabilityMass = expression.probabilityMass
+        
+        expect(probabilityMass) == expectedProbabilityMass
+    }
+    
+}

--- a/DiceKitTests/Successfulness_Tests.swift
+++ b/DiceKitTests/Successfulness_Tests.swift
@@ -1,0 +1,233 @@
+//
+//  Successfulness_Tests.swift
+//  DiceKit
+//
+//  Created by Brentley Jones on 8/8/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+class Successfulness_Tests: XCTestCase {
+    
+}
+
+// MARK: - Initialization
+extension Successfulness_Tests {
+    
+    func test_init_shouldBeIntegerLiteralConvertible() {
+        let undecidedLiteral: Successfulness = 0
+        let successLiteral1: Successfulness = 1
+        let successLiteral2: Successfulness = 45456
+        let failLiteral1: Successfulness = -1
+        let failLiteral2: Successfulness = -6567
+        
+        expect(undecidedLiteral) == Successfulness.Undetermined
+        expect(successLiteral1) == Successfulness.Success
+        expect(successLiteral2) == Successfulness.Success
+        expect(failLiteral1) == Successfulness.Fail
+        expect(failLiteral2) == Successfulness.Fail
+    }
+    
+}
+
+// MARK: - CustomPlaygroundQuickLookable
+extension Successfulness_Tests {
+    
+    func test_customPlaygroundQuickLook() {
+        switch Successfulness.Undetermined.customPlaygroundQuickLook() {
+        case PlaygroundQuickLook.Int(0): break
+        default: fail()
+        }
+        
+        switch Successfulness.Fail.customPlaygroundQuickLook() {
+        case PlaygroundQuickLook.Int(-1): break
+        default: fail()
+        }
+        
+        switch Successfulness.Success.customPlaygroundQuickLook() {
+        case PlaygroundQuickLook.Int(1): break
+        default: fail()
+        }
+    }
+    
+}
+
+// MARK: - Comparable
+extension Successfulness_Tests {
+    
+    func test_operator_lessThan() {
+        expect(Successfulness.Fail) < Successfulness.Success
+        expect(Successfulness.Fail) < Successfulness.Undetermined
+        expect(Successfulness.Undetermined) > Successfulness.Fail
+        expect(Successfulness.Undetermined) < Successfulness.Success
+        expect(Successfulness.Success) > Successfulness.Undetermined
+        expect(Successfulness.Success) > Successfulness.Fail
+    }
+    
+}
+
+// MARK: - Custom Logic
+extension Successfulness_Tests {
+    
+    func test_combineSuccessfulnesses_shouldPickCorrectlyForMany() {
+        property("combine successfulness") <- forAll {
+            (a: ArrayOf<Successfulness>) in
+            
+            let a = a.getArray
+            
+            let expectedSuccessfulness: Successfulness
+            switch (a.contains(.Success), a.contains(.Fail)) {
+            case (true, false):
+                expectedSuccessfulness = .Success
+            case (false, true):
+                expectedSuccessfulness = .Fail
+            case (false, false):
+                expectedSuccessfulness = .Undetermined
+            case (true, true): // Conflict
+                expectedSuccessfulness = .Undetermined
+            }
+            
+            let successfulness = Successfulness.combineSuccessfulnesses(a)
+            
+            return successfulness == expectedSuccessfulness
+        }
+    }
+    
+}
+
+// MARK: - AdditiveType, InvertibleAdditiveType, MultiplicativeType, InvertibleMultiplicativeType
+extension Successfulness_Tests {
+    
+    func test_operator_add() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                let expectedSuccessfulness: Successfulness
+                switch (lhsSuccessfulness, rhsSuccessfulness) {
+                case let (lhs, rhs) where lhs == rhs:
+                    expectedSuccessfulness = lhs
+                case let (.Undetermined, rhs):
+                    expectedSuccessfulness = rhs
+                case let (lhs, .Undetermined):
+                    expectedSuccessfulness = lhs
+                default: // In conflict
+                    expectedSuccessfulness = .Undetermined
+                }
+                
+                let successfulness = lhsSuccessfulness + rhsSuccessfulness
+                
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
+    
+    func test_operator_subtract() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                let expectedSuccessfulness: Successfulness
+                switch (lhsSuccessfulness, rhsSuccessfulness) {
+                case let (lhs, rhs) where lhs == rhs:
+                    expectedSuccessfulness = .Undetermined
+                case let (.Undetermined, rhs):
+                    expectedSuccessfulness = -rhs
+                case let (lhs, _): // Conflict 1 - -1 == 2 == 1
+                    expectedSuccessfulness = lhs
+                }
+                
+                let successfulness = lhsSuccessfulness - rhsSuccessfulness
+                
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
+    
+    func test_operator_multiply() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                let expectedSuccessfulness: Successfulness
+                switch (lhsSuccessfulness, rhsSuccessfulness) {
+                case (.Fail, .Fail):
+                    expectedSuccessfulness = .Success
+                case (.Success, .Success):
+                    expectedSuccessfulness = .Success
+                case (.Success, .Fail), (.Fail, .Success):
+                    expectedSuccessfulness = .Fail
+                default: // .Undetermined on either side
+                    expectedSuccessfulness = .Undetermined
+                }
+                
+                let successfulness = lhsSuccessfulness * rhsSuccessfulness
+                
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
+    
+    func test_operator_divide() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                let expectedSuccessfulness: Successfulness
+                switch (lhsSuccessfulness, rhsSuccessfulness) {
+                case (.Fail, .Fail):
+                    expectedSuccessfulness = .Success
+                case (.Success, .Success):
+                    expectedSuccessfulness = .Success
+                case (.Success, .Fail), (.Fail, .Success):
+                    expectedSuccessfulness = .Fail
+                case (_, .Undetermined):
+                    continue // Divide by zero
+                default: // .Undetermined on left size
+                    expectedSuccessfulness = .Undetermined
+                }
+                
+                let successfulness = lhsSuccessfulness / rhsSuccessfulness
+                
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
+    
+    func test_operator_remainder() {
+        let possibleSuccessfulessnesses: [Successfulness] = [.Undetermined, .Success, .Fail]
+        for lhsSuccessfulness in possibleSuccessfulessnesses {
+            for rhsSuccessfulness in possibleSuccessfulessnesses {
+                let expectedSuccessfulness: Successfulness
+                switch (lhsSuccessfulness, rhsSuccessfulness) {
+                case (_, .Undetermined):
+                    continue // Divide by zero
+                default: // Dealing with 1's, so they all become undetermined
+                    expectedSuccessfulness = .Undetermined
+                }
+                
+                let successfulness = lhsSuccessfulness % rhsSuccessfulness
+                
+                expect(successfulness) == expectedSuccessfulness
+            }
+        }
+    }
+    
+}
+
+// MARK: - FrequencyDistributionValueType
+extension Successfulness_Tests {
+    
+    func test_identities() {
+        expect(Successfulness.additiveIdentity) == Successfulness.Undetermined
+        expect(Successfulness.multiplicativeIdentity) == Successfulness.Success
+    }
+    
+    func test_multiplierEquivalent() {
+        expect(Successfulness.Undetermined.multiplierEquivalent) == 0
+        expect(Successfulness.Success.multiplierEquivalent) == 1
+        expect(Successfulness.Fail.multiplierEquivalent) == -1
+    }
+    
+}

--- a/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
@@ -18,5 +18,22 @@ let result = expression.evaluate()
 let value = result.value
 
 
+
+let dndD20 = SuccessfulnessExpression(d(20), successComparison: (.Equal, c(20)), failComparison: (.Equal, c(1)))
+let attackExpression = dndD20 + 10
+let attackVersusACExpression = SuccessfulnessExpression(attackExpression, successComparison: (.LessThan, c(23)), failComparison: (.GreaterThanOrEqual, c(23)))
+
+for (outcome, probability) in attackVersusACExpression.probabilityMass {
+    outcome.outcome
+    probability
+    outcome.successfulness
+}
+
+for _ in 0..<40 {
+    let result = dndD20.evaluate()
+    result.value
+    result.successfulness
+}
+
 //: [Previous](@previous)
 //: [Next](@next)

--- a/TomeOfKnowledge.playground/Pages/Probability.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Probability.xcplaygroundpage/Contents.swift
@@ -38,4 +38,40 @@ for (value, probability) in awesomeExpressionProbailityMass {
 }
 
 
+
+
+let successfulD6 = ProbabilityMass<OutcomeWithSuccessfulness>(FrequencyDistribution([1: 1, 2: 1, 3: 1, 4: 1, 5: 1, OutcomeWithSuccessfulness(6, .Success): 1]))
+for (value, probability) in successfulD6 {
+    value.successfulness
+    value
+    probability
+}
+
+let failureD6 = ProbabilityMass<OutcomeWithSuccessfulness>(FrequencyDistribution([OutcomeWithSuccessfulness(1, .Fail): 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1]))
+for (value, probability) in failureD6 {
+    value.successfulness
+    value
+    probability
+}
+
+let mixedSuccessD6 = successfulD6 && failureD6
+for (value, probability) in mixedSuccessD6 {
+    value.successfulness
+    value
+    probability
+}
+
+let prob = mixedSuccessD6[outcomeWithSuccessfulness: OutcomeWithSuccessfulness(4)]
+
+for (value, probability) in mixedSuccessD6.valuesWithoutSuccessfulness() {
+    value
+    probability
+}
+
+for (successfulness, probability) in mixedSuccessD6.successfulnessWithoutValues() {
+    successfulness
+    probability
+}
+
+
 //: [Previous](@previous)


### PR DESCRIPTION
Closes #4 and closes #59.
#### Features
- `Successfulness`, a type that represents if an expression was successful. `.Success`, `.Fail`, and `.Undetermined` are its current cases. `SuccessfulnessResultType` a type which `ExpressionResultType` conforms to, to allow all expression results to have successfulness.
  - [x] `SuccessfulnessResultType` Tests (all the expressions)
  - [ ] Playground
- `OutcomeWithSuccessfulness`, a way to represent successfulness with `ProbabilityMass`.
  - [x] Tests
- Extensions to `ProbabilityMass` specifically when using `OutcomeWithSuccessfulness`.
  - Reduce to probability regardless of successfulness
  - Reduce to probability only of successfulness
  - Map successfulness
  - Set new successfulness based on comparison with another expression
  - [x] Tests
  - [ ] Playground
- `SuccessfulnessExpression` to impose successfulness on an expression. Can of course wrap any expression and you can impose it multiple times.
  - [x] `SuccessfulnessExpression` Tests
  - [x] `SuccessfulnessExpressionResult` Tests
  - [ ] Playground
  - [ ] README Usage section
