### PR TITLE
`FrequencyDistribution` mapping fix

### DIFF
--- a/DiceKit/Dictionary+Functions.swift
+++ b/DiceKit/Dictionary+Functions.swift
@@ -20,7 +20,7 @@ extension Dictionary {
         return newDictionary
     }
     
-    /// - Warning: If two values are mapped to the same key, the last one evaluated will be used
+    /// - Warning: If two keys are mapped to the same key, the last one evaluated will be used. Use conflictTransform variant to provide a different behavior.
     func mapKeys(@noescape transform: (Key, Value) -> Key) -> [Key:Value] {
         var newDictionary: [Key:Value] = [:]
         
@@ -32,12 +32,40 @@ extension Dictionary {
         return newDictionary
     }
     
-    /// - Warning: If two values are mapped to the same key, the last one evaluated will be used
+    func mapKeys(@noescape conflictTransform: (Key, Value, Value) -> Value, @noescape transform: (Key, Value) -> Key) -> [Key:Value] {
+        var newDictionary: [Key:Value] = [:]
+        
+        for (key, var value) in self {
+            let newKey = transform(key, value)
+            if let existingValue = newDictionary[newKey] {
+                value = conflictTransform(newKey, existingValue, value)
+            }
+            newDictionary[newKey] = value
+        }
+        
+        return newDictionary
+    }
+    
+    /// - Warning: If two keys are mapped to the same key, the last one evaluated will be used. Use conflictTransform variant to provide a different behavior.
     func map(@noescape transform: (Key, Value) -> (Key, Value)) -> [Key:Value] {
         var newDictionary: [Key:Value] = [:]
         
         for (key, value) in self {
             let (newKey, newValue) = transform(key, value)
+            newDictionary[newKey] = newValue
+        }
+        
+        return newDictionary
+    }
+    
+    func map(@noescape conflictTransform: (Key, Value, Value) -> Value, @noescape transform: (Key, Value) -> (Key, Value)) -> [Key:Value] {
+        var newDictionary: [Key:Value] = [:]
+        
+        for (key, value) in self {
+            var (newKey, newValue) = transform(key, value)
+            if let existingValue = newDictionary[newKey] {
+                newValue = conflictTransform(newKey, existingValue, newValue)
+            }
             newDictionary[newKey] = newValue
         }
         

--- a/DiceKit/FrequencyDistribution.swift
+++ b/DiceKit/FrequencyDistribution.swift
@@ -123,7 +123,7 @@ extension FrequencyDistribution {
     // MARK: Foundational Operations
     
     public func mapOutcomes(@noescape transform: (Outcome) -> Outcome) -> FrequencyDistribution {
-        let newFrequenciesPerOutcome = frequenciesPerOutcome.mapKeys {
+        let newFrequenciesPerOutcome = frequenciesPerOutcome.mapKeys ({ $1 + $2 }) {
             (baseOutcome, _) in transform(baseOutcome)
         }
         

--- a/DiceKitTests/Dictionary+Functions_Tests.swift
+++ b/DiceKitTests/Dictionary+Functions_Tests.swift
@@ -35,12 +35,34 @@ class Dictionary_Functions_Tests: XCTestCase {
         expect(mappedKeys) == expected
     }
     
+    func test_mapKeysWithConflictResolution() {
+        let original = [2: 6, 3: 4, 7: 9, 64: 5]
+        let expected = [1: 10, 3: 9, 32: 5] // /2
+        
+        let mappedValues = original.mapKeys ({ $1 + $2}) {
+            (key, value) in key / 2
+        }
+        
+        expect(mappedValues) == expected
+    }
+    
     func test_map() {
         let original = [1: 6, 2:  4, 7: 9, 64: 5]
         let expected = [2: 1, 3: -1, 8: 4, 65: 0] // +1 keys, -5 values
         
         let mapped = original.map {
             (key, value) in (key + 1, value - 5)
+        }
+        
+        expect(mapped) == expected
+    }
+    
+    func test_mapWithConflictResolution() {
+        let original = [2: 6, 3: 4, 7: 9, 64: 5]
+        let expected = [1: 0, 3: 4, 32: 0] // /2 keys, -5 values
+        
+        let mapped = original.map ({ $1 + $2 }) {
+            (key, value) in (key/2, value - 5)
         }
         
         expect(mapped) == expected

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -132,6 +132,49 @@ extension FrequencyDistribution_Tests {
     
 }
 
+// MARK: - Foundational Operations
+extension FrequencyDistribution_Tests {
+    
+    func test_mapOutcomes() {
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            7: 3.0,
+            6: 2.5,
+            5: 1.5,
+            4: 1.0,
+        ]
+        let freqDist = FrequencyDistribution(frequenciesPerOutcome)
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            3: 5.5,
+            2: 2.5,
+        ] // /2
+        
+        let mappedOutcomes = freqDist.mapOutcomes { $0 / 2 }
+        
+        expect(mappedOutcomes.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
+    }
+    
+    func test_mapFrequencies() {
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            7: 3.0,
+            6: 2.5,
+            5: 1.5,
+            4: 1.0,
+        ]
+        let freqDist = FrequencyDistribution(frequenciesPerOutcome)
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [
+            7: 6.0,
+            6: 5.0,
+            5: 3.0,
+            4: 2.0,
+        ] // *2
+        
+        let mappedFrequencies = freqDist.mapFrequencies { $0 * 2 }
+        
+        expect(mappedFrequencies.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
+    }
+    
+}
+
 // MARK: - Primitive Operations
 extension FrequencyDistribution_Tests {
     


### PR DESCRIPTION
Wouldn't add together frequencies when mapping down the outcome to the same outcome.

Also added two more dictionary mapping methods.
