### PR TITLE
Support Subtraction of expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   [Jonathan Hoffman](https://github.com/JonathanHoffman)
   [#55](https://github.com/TabletopAssistant/DiceKit/pull/55)
 
+- :game_die: Add support for subtraction of expressions (e.g. `d20 - 5`)  
+  [Jonathan Hoffman](https://github.com/JonathanHoffman) [#80](https://github.com/TabletopAssistant/DiceKit/pull/80)
+
 ## 0.1: It Starts with a Single Die (2015-07-25)
 
 - :game_die: Support rolling individual dice.  

--- a/DiceKit.xcodeproj/project.pbxproj
+++ b/DiceKit.xcodeproj/project.pbxproj
@@ -50,6 +50,10 @@
 		53ECD0E41B5B5185002D859F /* NegationExpressionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53ECD0E31B5B5185002D859F /* NegationExpressionResult.swift */; };
 		53FA0EAC1B6579F300C8D3B5 /* ProbabilisticExpressionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FA0EAB1B6579F300C8D3B5 /* ProbabilisticExpressionType.swift */; };
 		53FA0EAE1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FA0EAD1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift */; };
+		8B4C14021B7F8B47008AC355 /* SubtractionExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4C14011B7F8B47008AC355 /* SubtractionExpression.swift */; };
+		8B4C14041B7FA8A2008AC355 /* SubtractionExpressionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4C14031B7FA8A2008AC355 /* SubtractionExpressionResult.swift */; };
+		8BFAA9F91B7ED8E800EF65AE /* SubtractionExpression_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFAA9F81B7ED8E800EF65AE /* SubtractionExpression_Tests.swift */; };
+		8BFAA9FB1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFAA9FA1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +131,10 @@
 		53ECD0E31B5B5185002D859F /* NegationExpressionResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NegationExpressionResult.swift; sourceTree = "<group>"; };
 		53FA0EAB1B6579F300C8D3B5 /* ProbabilisticExpressionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilisticExpressionType.swift; sourceTree = "<group>"; };
 		53FA0EAD1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProbabilisticExpressionType_Tests.swift; sourceTree = "<group>"; };
+		8B4C14011B7F8B47008AC355 /* SubtractionExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtractionExpression.swift; sourceTree = "<group>"; };
+		8B4C14031B7FA8A2008AC355 /* SubtractionExpressionResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtractionExpressionResult.swift; sourceTree = "<group>"; };
+		8BFAA9F81B7ED8E800EF65AE /* SubtractionExpression_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtractionExpression_Tests.swift; sourceTree = "<group>"; };
+		8BFAA9FA1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtractionExpressionResult_Tests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -194,6 +202,8 @@
 				533F88181B52BC6F003838C8 /* DiceKit.h */,
 				539D567D1B5B66CF00AC6A37 /* AdditionExpression.swift */,
 				539D567F1B5B689600AC6A37 /* AdditionExpressionResult.swift */,
+				8B4C14011B7F8B47008AC355 /* SubtractionExpression.swift */,
+				8B4C14031B7FA8A2008AC355 /* SubtractionExpressionResult.swift */,
 				53D1EC7D1B63133E00433D2C /* ApproximatelyEquatable.swift */,
 				534900331B78172900FA2804 /* ArithmeticType.swift */,
 				533D0C7C1B643F6C003A7D32 /* Constant.swift */,
@@ -235,6 +245,8 @@
 				533EB1ED1B5B293000B3F8A1 /* MultiplicationExpressionResult_Tests.swift */,
 				539D56831B5B6D1A00AC6A37 /* NegationExpression_Tests.swift */,
 				539D56851B5B6D2B00AC6A37 /* NegationExpressionResult_Tests.swift */,
+				8BFAA9F81B7ED8E800EF65AE /* SubtractionExpression_Tests.swift */,
+				8BFAA9FA1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift */,
 				53FA0EAD1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift */,
 				533D0C7A1B6423FA003A7D32 /* ProbabilityMass_Tests.swift */,
 			);
@@ -391,8 +403,10 @@
 				539EAC5B1B6DB97C0097C116 /* FrequencyDistributionIndex.swift in Sources */,
 				5379780B1B531B21005818EC /* Die.swift in Sources */,
 				53D05ED11B53417D007CE7FC /* Int+Random.swift in Sources */,
+				8B4C14021B7F8B47008AC355 /* SubtractionExpression.swift in Sources */,
 				53ECD0E21B5B498A002D859F /* NegationExpression.swift in Sources */,
 				539D56801B5B689600AC6A37 /* AdditionExpressionResult.swift in Sources */,
+				8B4C14041B7FA8A2008AC355 /* SubtractionExpressionResult.swift in Sources */,
 				539D568E1B5C7BDA00AC6A37 /* ProbabilityMass.swift in Sources */,
 				53CFC30D1B5AD3BF009C6C8F /* ExpressionType.swift in Sources */,
 				53CFC30F1B5AD674009C6C8F /* MultiplicationExpression.swift in Sources */,
@@ -407,6 +421,7 @@
 			files = (
 				539D56841B5B6D1A00AC6A37 /* NegationExpression_Tests.swift in Sources */,
 				53FA0EAE1B657A3600C8D3B5 /* ProbabilisticExpressionType_Tests.swift in Sources */,
+				8BFAA9F91B7ED8E800EF65AE /* SubtractionExpression_Tests.swift in Sources */,
 				531E4F611B7400270073F01A /* Arbitrary.swift in Sources */,
 				533EB1EE1B5B293000B3F8A1 /* MultiplicationExpressionResult_Tests.swift in Sources */,
 				53CFC3111B5AE4A0009C6C8F /* MultiplicationExpression_Tests.swift in Sources */,
@@ -421,6 +436,7 @@
 				538AD9691B7678B7001B5CB5 /* Die.Roll_Tests.swift in Sources */,
 				538AD9651B75A66F001B5CB5 /* MockExpression.swift in Sources */,
 				531E4F5F1B73F5E20073F01A /* EquatableTestUtilities.swift in Sources */,
+				8BFAA9FB1B7F708000EF65AE /* SubtractionExpressionResult_Tests.swift in Sources */,
 				533D0C7B1B6423FA003A7D32 /* ProbabilityMass_Tests.swift in Sources */,
 				53D1EC801B63DF0C00433D2C /* Dictionary+Functions_Tests.swift in Sources */,
 			);

--- a/DiceKit/Dictionary+Functions.swift
+++ b/DiceKit/Dictionary+Functions.swift
@@ -72,4 +72,16 @@ extension Dictionary {
         return newDictionary
     }
     
+    func filterValues(@noescape includeElement: Value -> Bool) -> [Key:Value] {
+        var newDictionary: [Key:Value] = [:]
+        
+        for (key, value) in self {
+            if includeElement(value) {
+                newDictionary[key] = value
+            }
+        }
+        
+        return newDictionary
+    }
+    
 }

--- a/DiceKit/Dictionary+Functions.swift
+++ b/DiceKit/Dictionary+Functions.swift
@@ -72,11 +72,35 @@ extension Dictionary {
         return newDictionary
     }
     
-    func filterValues(@noescape includeElement: Value -> Bool) -> [Key:Value] {
-        var newDictionary: [Key:Value] = [:]
+    func filterValues(@noescape includeElement: Value -> Bool) -> [Key: Value] {
+        var newDictionary: [Key: Value] = [:]
         
         for (key, value) in self {
             if includeElement(value) {
+                newDictionary[key] = value
+            }
+        }
+        
+        return newDictionary
+    }
+    
+    func filterKeys(@noescape includeElement: Key -> Bool) -> [Key: Value] {
+        var newDictionary: [Key: Value] = [:]
+        
+        for (key, value) in self {
+            if includeElement(key) {
+                newDictionary[key] = value
+            }
+        }
+        
+        return newDictionary
+    }
+    
+    func filter(@noescape includeElement: (Key, Value) -> Bool) -> [Key: Value] {
+        var newDictionary: [Key: Value] = [:]
+        
+        for (key, value) in self {
+            if includeElement(key, value) {
                 newDictionary[key] = value
             }
         }

--- a/DiceKit/FrequencyDistribution.swift
+++ b/DiceKit/FrequencyDistribution.swift
@@ -198,6 +198,11 @@ extension FrequencyDistribution {
         return mapFrequencies { $0 / frequencies }
     }
     
+    public func removeZeroes(delta: Frequency) -> FrequencyDistribution {
+        let newFrequenciesPerOutcome = frequenciesPerOutcome.filterValues( {$0 > delta})
+        return FrequencyDistribution(newFrequenciesPerOutcome)
+    }
+    
     // MARK: Advanced Operations
     
     public func add(x: FrequencyDistribution) -> FrequencyDistribution {
@@ -213,6 +218,17 @@ extension FrequencyDistribution {
     
     // TODO: public func subtract(x: FrequencyDistribution) -> FrequencyDistribution
     // Probably needed to support divide
+    public func subtract(x: FrequencyDistribution) -> FrequencyDistribution {
+        var newFrequenciesPerOutcome = frequenciesPerOutcome
+        for (outcome, frequency) in x.frequenciesPerOutcome {
+            let exisitingFrequency = newFrequenciesPerOutcome[outcome] ?? 0
+            let newFrequency = exisitingFrequency - frequency
+            newFrequenciesPerOutcome[outcome] = newFrequency
+        }
+        
+        let delta: Double = ProbabilityMassConfig.probabilityEqualityDelta
+        return FrequencyDistribution(newFrequenciesPerOutcome).removeZeroes(delta)
+    }
     
     public func multiply(x: FrequencyDistribution) -> FrequencyDistribution {
         return frequenciesPerOutcome.reduce(.additiveIdentity) {

--- a/DiceKit/ProbabilityMass.swift
+++ b/DiceKit/ProbabilityMass.swift
@@ -123,6 +123,12 @@ extension ProbabilityMass {
         return ProbabilityMass(freqDist, normalize: true)
     }
     
+    public func not(x: ProbabilityMass) -> ProbabilityMass {
+        let freqDist = frequencyDistribution.divide(x.frequencyDistribution)
+        
+        return ProbabilityMass(freqDist, normalize: true)
+    }
+    
     public func product(x: ProbabilityMass) -> ProbabilityMass {
         let freqDist = frequencyDistribution.power(x.frequencyDistribution)
         
@@ -149,6 +155,16 @@ public func ^^ <V>(lhs: ProbabilityMass<V>, rhs: ProbabilityMass<V>) -> Probabil
 
 public func && <V>(lhs: ProbabilityMass<V>, rhs: ProbabilityMass<V>) -> ProbabilityMass<V> {
     return lhs.and(rhs)
+}
+
+// Not operator
+infix operator !&& {
+    associativity left
+    precedence 140
+}
+
+public func !&& <V>(lhs: ProbabilityMass<V>, rhs: ProbabilityMass<V>) -> ProbabilityMass<V> {
+    return lhs.not(rhs)
 }
 
 public func * <V>(lhs: ProbabilityMass<V>, rhs: ProbabilityMass<V>) -> ProbabilityMass<V> {

--- a/DiceKit/SubtractionExpression.swift
+++ b/DiceKit/SubtractionExpression.swift
@@ -1,0 +1,80 @@
+//
+//  SubtractionExpression.swift
+//  DiceKit
+//
+//  Created by Jonathan Hoffman on 8/15/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import Foundation
+
+public struct SubtractionExpression<LeftExpression: protocol<ExpressionType, Equatable>, RightExpression: protocol<ExpressionType, Equatable>>: Equatable {
+    
+    public let minuend: LeftExpression
+    public let subtrahend: RightExpression
+    
+    public init(_ minuend: LeftExpression, _ subtrahend: RightExpression) {
+        self.minuend = minuend
+        self.subtrahend = subtrahend
+    }
+    
+}
+
+// MARK: - ExpressionType
+
+extension SubtractionExpression: ExpressionType {
+    
+    public typealias Result = SubtractionExpressionResult<LeftExpression.Result, RightExpression.Result>
+    
+    public func evaluate() -> Result {
+        let leftResult = minuend.evaluate()
+        let rightResult = subtrahend.evaluate()
+        
+        return Result(leftResult, rightResult)
+    }
+    
+    public var probabilityMass: ExpressionProbabilityMass {
+        return minuend.probabilityMass && subtrahend.probabilityMass.negate()
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+
+extension SubtractionExpression: CustomStringConvertible {
+    
+    public var description: String {
+        return "\(minuend) - \(subtrahend)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension SubtractionExpression: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "\(String(reflecting: minuend)) - \(String(reflecting: subtrahend))"
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == <L, R>(lhs: SubtractionExpression<L, R>, rhs: SubtractionExpression<L, R>) -> Bool {
+    return lhs.minuend == rhs.minuend && lhs.subtrahend == rhs.subtrahend
+}
+
+// MARK: - Operators
+
+public func - <L: protocol<ExpressionType, Equatable>, R: protocol<ExpressionType, Equatable>>(lhs: L, rhs: R) -> SubtractionExpression<L, R> {
+    return SubtractionExpression(lhs, rhs)
+}
+
+public func - <R: protocol<ExpressionType, Equatable>>(lhs: Int, rhs: R) -> SubtractionExpression<Constant, R> {
+    return SubtractionExpression(Constant(lhs), rhs)
+}
+
+public func - <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: Int) -> SubtractionExpression<L, Constant> {
+    return SubtractionExpression(lhs, Constant(rhs))
+}

--- a/DiceKit/SubtractionExpressionResult.swift
+++ b/DiceKit/SubtractionExpressionResult.swift
@@ -1,0 +1,58 @@
+//
+//  SubtractionExpressionResult.swift
+//  DiceKit
+//
+//  Created by Developer on 8/15/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import Foundation
+
+public struct SubtractionExpressionResult<MinuendResult: protocol<ExpressionResultType, Equatable>, SubtrahendResult: protocol<ExpressionResultType, Equatable>>: Equatable {
+    
+    public let minuendResult: MinuendResult
+    public let subtrahendResult: SubtrahendResult
+    
+    public init(_ minuendResult: MinuendResult, _ subtrahendResult: SubtrahendResult) {
+        self.minuendResult = minuendResult
+        self.subtrahendResult = subtrahendResult
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+
+extension SubtractionExpressionResult: CustomStringConvertible {
+    
+    public var description: String {
+        return "\(minuendResult) - \(subtrahendResult)"
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension SubtractionExpressionResult: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "\(String(reflecting: minuendResult)) - \(String(reflecting: subtrahendResult))"
+    }
+    
+}
+
+// MARK: - Equatable
+
+public func == <L, R>(lhs: SubtractionExpressionResult<L,R>, rhs: SubtractionExpressionResult<L,R>) -> Bool {
+    return lhs.minuendResult == rhs.minuendResult && lhs.subtrahendResult == rhs.subtrahendResult
+}
+
+// MARK: - ExpressionResultType
+
+extension SubtractionExpressionResult: ExpressionResultType {
+    
+    public var value: Int {
+        return minuendResult.value - subtrahendResult.value
+    }
+    
+}
+

--- a/DiceKitTests/Dictionary+Functions_Tests.swift
+++ b/DiceKitTests/Dictionary+Functions_Tests.swift
@@ -68,4 +68,12 @@ class Dictionary_Functions_Tests: XCTestCase {
         expect(mapped) == expected
     }
 
+    func test_filterValues() {
+        let original = [1: 1, 2: 4, 3: 9, 4: 16]
+        let expected = [1: 1, 2: 4]
+        
+        let filtered = original.filterValues({$0 < 5})
+        
+        expect(filtered) == expected
+    }
 }

--- a/DiceKitTests/Dictionary+Functions_Tests.swift
+++ b/DiceKitTests/Dictionary+Functions_Tests.swift
@@ -69,10 +69,28 @@ class Dictionary_Functions_Tests: XCTestCase {
     }
 
     func test_filterValues() {
-        let original = [1: 1, 2: 4, 3: 9, 4: 16]
-        let expected = [1: 1, 2: 4]
+        let original = [1: 10, 2: -4, 3: 99, 4: -200]
+        let expected = [1: 10, 3: 99]
         
-        let filtered = original.filterValues({$0 < 5})
+        let filtered = original.filterValues { $0 > 5 }
+        
+        expect(filtered) == expected
+    }
+    
+    func test_filterKeys() {
+        let original = [-2: 24, -1: -9, 0: 42, 1: 9000, 2: -10]
+        let expected = [-2: 24, -1: -9]
+        
+        let filtered = original.filterKeys {$0 < 0}
+        
+        expect(filtered) == expected
+    }
+    
+    func test_filterDict() {
+        let original = [-2: 20, -1: 10, 0: 42, 1: 612, 2: -666]
+        let expected = [-2: 20, 1: 612]
+        
+        let filtered = original.filter {$0 == -2 || $1 == 612}
         
         expect(filtered) == expected
     }

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -34,6 +34,14 @@ extension FrequencyDistribution_Tests {
         }
     }
     
+    func test_init_shouldFilterZeroFrequencies() {
+        let inputFrequenciesPerOutcome = [1: 1.0, 2: 0.0, 3: 1.23]
+        let expected = [1: 1.0, 3: 1.23]
+        
+        let result = FrequencyDistribution(inputFrequenciesPerOutcome).frequenciesPerOutcome
+        
+        expect(result) == expected
+    }
 }
 
 // MARK: - Equatable
@@ -191,8 +199,8 @@ extension FrequencyDistribution_Tests {
     }
     
     func test_approximatelyEqual_shouldNotEqualForDifferentNumberOfValues() {
-        let delta = 1e-16 // 64-bit. What about 32-bit?
-        let outcome = 0.0
+        let delta = 2e-15 // 64-bit. What about 32-bit?
+        let outcome = 1.0
         let x = FrequencyDistribution([1: outcome])
         let y = FrequencyDistribution([1: outcome, 2: outcome])
         
@@ -202,9 +210,9 @@ extension FrequencyDistribution_Tests {
     }
     
     func test_approximatelyEqual_shouldEqualForSame() {
-        let delta = 1e-16 // 64-bit. What about 32-bit?
-        let xOutcome = 0.0
-        let yOutcome = 0.0
+        let delta = 2e-15 // 64-bit. What about 32-bit?
+        let xOutcome = 1.0
+        let yOutcome = 1.0
         let x = FrequencyDistribution([1: xOutcome])
         let y = FrequencyDistribution([1: yOutcome])
         
@@ -214,9 +222,9 @@ extension FrequencyDistribution_Tests {
     }
     
     func test_approximatelyEqual_shouldEqualWithinDelta() {
-        let delta = 1e-16 // 64-bit. What about 32-bit?
-        let xOutcome = 0.0
-        let yOutcome = 0.0 + delta - delta/10
+        let delta = 2e-15 // 64-bit. What about 32-bit?
+        let xOutcome = 1.0
+        let yOutcome = 1.0 + delta - delta/10
         let x = FrequencyDistribution([1: xOutcome])
         let y = FrequencyDistribution([1: yOutcome])
         
@@ -226,9 +234,9 @@ extension FrequencyDistribution_Tests {
     }
     
     func test_approximatelyEqual_shouldNotEqualOutsideDelta() {
-        let delta = 1e-16 // 64-bit. What about 32-bit?
-        let xOutcome = 0.0
-        let yOutcome = 0.0 + delta + delta/10
+        let delta = 2e-15 // 64-bit. What about 32-bit?
+        let xOutcome = 1.0
+        let yOutcome = 1.0 + delta + delta/10
         let x = FrequencyDistribution([1: xOutcome])
         let y = FrequencyDistribution([1: yOutcome])
         

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -281,12 +281,12 @@ extension FrequencyDistribution_Tests {
         expect(normalized.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
     }
     
-    func test_removeZeroes() {
+    func test_filterZeroFrequencies() {
         let delta: Double = ProbabilityMassConfig.probabilityEqualityDelta
-        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 2:0.0, 3:100.0, 4:(delta * 0.9)]
-        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 3:100.0]
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 2:0.0, 3:100.0, 4:(delta * 0.9), 5: -42.0]
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 3:100.0, 5: -42.0]
         
-        let result = FrequencyDistribution(frequenciesPerOutcome).removeZeroes(delta)
+        let result = FrequencyDistribution(frequenciesPerOutcome).filterZeroFrequencies(delta)
         
         expect(result.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
     }
@@ -348,6 +348,19 @@ extension FrequencyDistribution_Tests {
         expect(z) == expected
     }
     
+    func test_divide() {
+        //Does the reverse of multiply
+        let xFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:3.0, 2:2.0, 6:1.0]
+        let yFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [2:2.0, 3:2.0, 7:1.0]
+        let zFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [3:6.0, 4:10.0, 5:4.0, 8:5.0, 9:4.0, 13:1.0]
+        let z = FrequencyDistribution(zFrequenciesPerOutcome)
+        let y = FrequencyDistribution(yFrequenciesPerOutcome)
+        let expected = FrequencyDistribution(xFrequenciesPerOutcome)
+        
+        let x = z.divide(y)
+        
+        expect(x) == expected
+    }
     func test_power_shouldReturnMultiplicativeIdentityFor0() {
         let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [2:2.0, 3:2.0, 6:1.0]
         let expected = FrequencyDistribution<Int>.multiplicativeIdentity

--- a/DiceKitTests/FrequencyDistribution_Tests.swift
+++ b/DiceKitTests/FrequencyDistribution_Tests.swift
@@ -281,6 +281,15 @@ extension FrequencyDistribution_Tests {
         expect(normalized.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
     }
     
+    func test_removeZeroes() {
+        let delta: Double = ProbabilityMassConfig.probabilityEqualityDelta
+        let frequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 2:0.0, 3:100.0, 4:(delta * 0.9)]
+        let expectedFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 3:100.0]
+        
+        let result = FrequencyDistribution(frequenciesPerOutcome).removeZeroes(delta)
+        
+        expect(result.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
+    }
 }
 
 // MARK: - Advanced Operations
@@ -299,6 +308,18 @@ extension FrequencyDistribution_Tests {
         expect(z.frequenciesPerOutcome) == expectedFrequenciesPerOutcome
     }
     
+    func test_subtract() {
+        let xFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [1:1.0, 2:1.0, 3:4.0, 4:1.0]
+        let yFrequenciesPerOutcome: FrequencyDistribution.FrequenciesPerOutcome = [4:6.0, 7:1.0, 8:0.5, 22:3.0]
+        let x = FrequencyDistribution(xFrequenciesPerOutcome)
+        let y = FrequencyDistribution(yFrequenciesPerOutcome)
+        let z = x.add(y)
+        
+        // x + y - y = x
+        let result = z.subtract(y)
+        
+        expect(result.frequenciesPerOutcome) == x.frequenciesPerOutcome
+    }
     func test_multiply() {
         // TODO: SwiftCheck
         /*

--- a/DiceKitTests/ProbabilityMass_Tests.swift
+++ b/DiceKitTests/ProbabilityMass_Tests.swift
@@ -217,6 +217,16 @@ extension ProbabilityMass_Tests {
         expect(probMass.frequencyDistribution) == expectedFreqDist
     }
     
+    func test_not_shouldDivideFrequencyDistributions() {
+        let x = operationFixture1
+        let y = operationFixture2
+        let z = x.and(y)
+        
+        let probMass = z.not(y)
+        
+        expect(probMass) == x
+    }
+    
     func test_product_shouldPowerFrequerncyDistributions() {
         let x = operationFixture1
         let y = operationFixture1
@@ -257,6 +267,16 @@ extension ProbabilityMass_Tests {
         let expectedProbMass = x.and(y)
         
         let probMass = x && y
+        
+        expect(probMass) == expectedProbMass
+    }
+    
+    func test_notOperator_callsNot() {
+        let x = operationFixture1
+        let y = operationFixture2
+        let expectedProbMass = x.not(y)
+        
+        let probMass = x !&& y
         
         expect(probMass) == expectedProbMass
     }

--- a/DiceKitTests/SubtractionExpressionResult_Tests.swift
+++ b/DiceKitTests/SubtractionExpressionResult_Tests.swift
@@ -1,0 +1,128 @@
+//
+//  SubtractionExpressionResult_Tests.swift
+//  DiceKit
+//
+//  Created by Jonathan Hoffman on 8/15/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+/// Tests the `SubtractionExpressionResult` type
+class SubtractionExpressionResult_Tests: XCTestCase {
+    
+}
+
+// MARK: - Equatable
+extension SubtractionExpressionResult_Tests {
+    
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return EquatableTestUtilities.checkReflexive { SubtractionExpressionResult(a, b) }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return EquatableTestUtilities.checkSymmetric { SubtractionExpressionResult(a, b) }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return EquatableTestUtilities.checkTransitive { SubtractionExpressionResult(a, b) }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: Constant, b: Constant, m: Constant, n: Constant) in
+            
+            return (!(a == m && b == n) && !(a == n && b == m)) ==> {
+                EquatableTestUtilities.checkNotEquate(
+                    { SubtractionExpressionResult(a, b) },
+                    { SubtractionExpressionResult(m, n) }
+                )
+            }
+        }
+    }
+    
+    func test_shouldBeAnticommutative() {
+        property("Anticommutative") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return (a != b) ==> {
+                let x = SubtractionExpression(a, b).evaluate()
+                let y = SubtractionExpression(b, a).evaluate()
+                
+                let testNoncommutative = x != y
+                let testAnticommutative = x.value == -y.value
+                
+                return testNoncommutative && testAnticommutative
+            }
+        }
+    }
+    
+}
+
+// MARK: - ExpressionResultType
+extension SubtractionExpressionResult_Tests {
+    
+    func test_value_shouldSubtractSubtrahendFromMinuend() {
+        property("Subtract subtrahend from minuend") <- forAll {
+            (a: Int16, b: Int16) in
+            
+            let minuend = Int(a)
+            let subtrahend = Int(b)
+            
+            let expectedValue = minuend - subtrahend
+            
+            let result = SubtractionExpressionResult(c(minuend), c(subtrahend))
+            
+            let value = result.value
+            
+            return value == expectedValue
+        }
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+extension SubtractionExpressionResult_Tests {
+    
+    func test_CustomDebuStringConvertible() {
+        let expression = d(10) - 5
+        let evaluation = expression.evaluate()
+        let expected = "Die(10).Roll(\(evaluation.minuendResult.value)) - Constant(5)"
+        
+        let result = String(reflecting: evaluation)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// Mark: - CustomStringConvertible
+extension SubtractionExpressionResult_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = d(10) - 5
+        let evaluation = expression.evaluate()
+        let expected = "\(evaluation.minuendResult.value)|10 - 5"
+        
+        let result = String(evaluation)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/DiceKitTests/SubtractionExpression_Tests.swift
+++ b/DiceKitTests/SubtractionExpression_Tests.swift
@@ -1,0 +1,172 @@
+//
+//  SubtractionExpression_Tests.swift
+//  DiceKit
+//
+//  Created by Jonathan Hoffman on 8/14/15.
+//  Copyright © 2015 Brentley Jones. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+import Nimble
+import SwiftCheck
+
+import DiceKit
+
+/// Tests the `SubtractionExpression` type
+class SubtractionExpression_Tests: XCTestCase {
+    
+}
+
+// MARK: - Equatable
+extension SubtractionExpression_Tests {
+    
+    func test_shouldBeReflexive() {
+        property("reflexive") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return EquatableTestUtilities.checkReflexive { SubtractionExpression(a, b) }
+        }
+    }
+    
+    func test_shouldBeSymmetric() {
+        property("symmetric") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return EquatableTestUtilities.checkSymmetric { SubtractionExpression(a, b) }
+        }
+    }
+    
+    func test_shouldBeTransitive() {
+        property("transitive") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return EquatableTestUtilities.checkTransitive { SubtractionExpression(a, b) }
+        }
+    }
+    
+    func test_shouldBeAbleToNotEquate() {
+        property("non-equal") <- forAll {
+            (a: Constant, b: Constant, m: Constant, n: Constant) in
+            
+            return !(a == m && b == n) ==> {
+                return EquatableTestUtilities.checkNotEquate(
+                    { SubtractionExpression(a, b) },
+                    { SubtractionExpression(m, n) }
+                )
+            }
+        }
+    }
+    
+    func test_shouldBeNoncommutative() {
+        property("Noncommutative") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            return a != b ==> {
+                
+                let x = SubtractionExpression(a, b)
+                let y = SubtractionExpression(b, a)
+                
+                return x != y
+            }
+        }
+    }
+    
+}
+
+// MARK: - ExpressionType
+extension SubtractionExpression_Tests {
+    
+    func test_evaluate_shouldCreateResultCorrectly() {
+        property("create results") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            let expression = SubtractionExpression(a, b)
+            
+            let result = expression.evaluate()
+            
+            return result.minuendResult == a && result.subtrahendResult == b
+        }
+    }
+    
+    func test_probabilityMass_shouldReturnCorrect() {
+        property("probability mass") <- forAll {
+            (a: Constant, b: Constant) in
+            
+            let negB = -b
+            let expectedProbMass = a.probabilityMass.and(negB.probabilityMass)
+            let expression = SubtractionExpression(a, b)
+            
+            let probMass = expression.probabilityMass
+            
+            return probMass == expectedProbMass
+        }
+    }
+    
+}
+
+// MARK: - Operators
+extension SubtractionExpression_Tests {
+    
+    func test_operator_shouldWorkWithIntAndExpression() {
+        property("Int - Expression and Expression - Int returns correct SubtractionExpression") <- forAll {
+            (a: Int, b: Int) in
+            
+            let die = d(b)
+            let expectedExpression1 = SubtractionExpression(c(a), die)
+            let expectedExpression2 = SubtractionExpression(die, c(a))
+            
+            let expression1 = a - die
+            let expression2 = die - a
+            
+            let test1 = (expression1 == expectedExpression1)
+            let test2 = (expression2 == expectedExpression2)
+            
+            return test1 && test2
+        }
+    }
+    
+    func test_operator_shouldWorkWithExpressionAndExpression() {
+        property("Expression - Expression returns correct SubtractionExpresson") <- forAll {
+            (a: Int, b: Int) in
+            
+            let leftDie = d(a)
+            let rightDie = d(b)
+            let expectedExpression = SubtractionExpression(leftDie, rightDie)
+            
+            let expression = leftDie - rightDie
+            
+            return expression == expectedExpression
+        }
+    }
+    
+}
+
+// MARK: - CustomDebugStringConvertible
+extension SubtractionExpression_Tests {
+    
+    func test_CustomDebugStringConvertible() {
+        let expression = d(8) - 2
+        let expected = "Die(8) - Constant(2)"
+        
+        let result = String(reflecting: expression)
+        
+        expect(result) == expected
+    }
+    
+}
+
+// MARK: - CustomStringConvertible
+extension SubtractionExpression_Tests {
+    
+    func test_CustomStringConvertible() {
+        let expression = d(20) - d(4)
+        let expected = "d20 - d4"
+        
+        let result = String(expression)
+        
+        expect(result) == expected
+    }
+    
+}

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ DiceKit
 [![Latest release](https://img.shields.io/github/release/tabletopassistant/dicekit.svg)](https://github.com/TabletopAssistant/DiceKit/releases)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage)
 
-DiceKit is a Swift framework for expressing and evaluating [dice notation][Dice Notation] (e.g., `d20`, `4d6+4`, `3d8×10+2`), which is commonly used in tabletop role-playing games.
+DiceKit is a Swift framework for expressing and evaluating [dice notation][Dice Notation] (e.g., `d20`, `4d6-4`, `3d8×10+2`), which is commonly used in tabletop role-playing games.
 
 [Dice Notation]: https://en.wikipedia.org/wiki/Dice_notation
 
 ## Features
 
 - [x] Roll dice with arbitrary number of sides (e.g., `d2`, `d7`, `d6538`)
-- [x] Evaluate simple dice expressions, including addition, multiplication, and negation operations (e.g. `2d20 + 6(1d5 + 8)`)
+- [x] Evaluate simple dice expressions, including addition, subtraction, multiplication, and negation operations (e.g. `2d20 + 6(1d5 + 8)`)
 - [ ] Evaluate complicated dice expressions, including division, dropping dice, and exploding dice – [#27](https://github.com/TabletopAssistant/DiceKit/issues/27), [#28](https://github.com/TabletopAssistant/DiceKit/issues/28), [#33](https://github.com/TabletopAssistant/DiceKit/issues/33)
 - [x] Determine the probability distribution of an expression
 - [ ] Determine if an expression result meets success criteria  – [#59](https://github.com/TabletopAssistant/DiceKit/issues/59)

--- a/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/Contents.swift
@@ -36,6 +36,9 @@ let oneD2d3result = oneD2d3.evaluate()
 let value = oneD2d3result.value
 
 //: Try making more expressions in this playground. There is no limitation on what expression types you can put together to make a new expression. If your expression gets too complicated to easily tell its type, use the `dump()` function to investigate it in the console window.
+let whatIsThisExpression = d3 * (d(20) - 2)
+dump(whatIsThisExpression) //Check out the debug area for a handy expression tree! :)
+
 
 //: [Previous](@previous)
 //: [Next](@next)

--- a/TomeOfKnowledge.playground/Pages/Probability.xcplaygroundpage/timeline.xctimeline
+++ b/TomeOfKnowledge.playground/Pages/Probability.xcplaygroundpage/timeline.xctimeline
@@ -3,84 +3,84 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=55&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.521594"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=55&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.701569"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=41&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.521971"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=41&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.701802"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1134&amp;EndingColumnNumber=17&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167373.462574"
+         documentLocation = "#CharacterRangeLen=18&amp;CharacterRangeLoc=1134&amp;EndingColumnNumber=17&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.701942"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=39&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.522556"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=39&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.702073"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=42&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.522849"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=42&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.702199"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=57&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.523142"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=57&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.702339"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=65&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.523428"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=65&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.70249"
          selectedRepresentationIndex = "2"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=37&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.523719"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=37&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.702627"
          lockedSize = "{175, 78}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=36&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.524021"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=36&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.702779"
          lockedSize = "{175, 77}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=39&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=460167401.52432"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1501&amp;EndingColumnNumber=39&amp;EndingLineNumber=33&amp;StartingColumnNumber=5&amp;StartingLineNumber=33&amp;Timestamp=461133216.703109"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1488&amp;EndingColumnNumber=16&amp;EndingLineNumber=31&amp;StartingColumnNumber=5&amp;StartingLineNumber=31&amp;Timestamp=460167401.524603"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1488&amp;EndingColumnNumber=16&amp;EndingLineNumber=31&amp;StartingColumnNumber=5&amp;StartingLineNumber=31&amp;Timestamp=461133216.703262"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1041&amp;EndingColumnNumber=16&amp;EndingLineNumber=22&amp;StartingColumnNumber=5&amp;StartingLineNumber=22&amp;Timestamp=460167338.605225"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=1041&amp;EndingColumnNumber=16&amp;EndingLineNumber=22&amp;StartingColumnNumber=5&amp;StartingLineNumber=22&amp;Timestamp=461133216.70341"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=725&amp;EndingColumnNumber=16&amp;EndingLineNumber=13&amp;StartingColumnNumber=5&amp;StartingLineNumber=13&amp;Timestamp=460167299.616627"
+         documentLocation = "#CharacterRangeLen=11&amp;CharacterRangeLoc=725&amp;EndingColumnNumber=16&amp;EndingLineNumber=13&amp;StartingColumnNumber=5&amp;StartingLineNumber=13&amp;Timestamp=461133216.703551"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=715&amp;EndingColumnNumber=10&amp;EndingLineNumber=12&amp;StartingColumnNumber=5&amp;StartingLineNumber=12&amp;Timestamp=460167299.623165"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=715&amp;EndingColumnNumber=10&amp;EndingLineNumber=12&amp;StartingColumnNumber=5&amp;StartingLineNumber=12&amp;Timestamp=461133216.703743"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1478&amp;EndingColumnNumber=10&amp;EndingLineNumber=30&amp;StartingColumnNumber=5&amp;StartingLineNumber=30&amp;Timestamp=460167401.541682"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1478&amp;EndingColumnNumber=10&amp;EndingLineNumber=30&amp;StartingColumnNumber=5&amp;StartingLineNumber=30&amp;Timestamp=461133216.703892"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1031&amp;EndingColumnNumber=10&amp;EndingLineNumber=21&amp;StartingColumnNumber=5&amp;StartingLineNumber=21&amp;Timestamp=460167401.541682"
+         documentLocation = "#CharacterRangeLen=5&amp;CharacterRangeLoc=1031&amp;EndingColumnNumber=10&amp;EndingLineNumber=21&amp;StartingColumnNumber=5&amp;StartingLineNumber=21&amp;Timestamp=461133216.704039"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
TODO:
- [x] Add dictionary support for filter method
- [x] Add method to remove zeroes from a frequency distribution
- [x] Add subtract method for frequency distributions
- [x] Add divide method for frequency distributions
- [x] Add method to deconvolute a probability mass function
- [x] Add subtraction type
- [x] Add examples to playground, update readme
- [x] Expand dictionary filter method

Notes:
- ~~Deltas: Should I pass the delta we want to the removeZeroes function, or just use the default set in ProbabilityMassConfig? Or just set delta to the value where ever it is used?~~
- So far I have only implemented the filter function that I need. Should I add more? 
- I spent a lot of time designing divide, but I think more testing is needed. I might implement a SwiftCheck for it. 
- Divide can also be implemented and optimized using FFT. I think our implementation could have a O(n log n) upper bound on complexity (currently O(n<sup>2</sup>) I think). 

Closes #63
