### PR TITLE
Update SwiftCheck

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "9a40cc4142a00ed1a8a58d318c6f545a39d173e9"
-github "typelift/SwiftCheck" "4f74ca9d81faf822e10d81c9b22aa27478c64986"
+github "typelift/SwiftCheck" "06acd45e23a80ced3ef590b683549d14b8b232f6"
 github "mrackwitz/xcconfigs" "bd51f1f617d688f4a00f1ea9d6b1e87a24104592"


### PR DESCRIPTION
Has our `Bool` & sign fixes.

Requires Swift 2 Beta 5. So blocked until Bitrise updates their VMs (most likely the weekend of the 15th).
