### PR TITLE
probabilityMass for a negative sided die.

### DIFF
--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -116,7 +116,7 @@ extension Die: ExpressionType {
         
         var frequenciesPerOutcome = FrequencyDistribution<ExpressionProbabilityMass.Outcome>.FrequenciesPerOutcome()
         let frequencyPerOutcome = 1.0/ExpressionProbabilityMass.Probability(abs(sides))
-        let range = sides < 0 ? sides...1 : 1...sides
+        let range = sides < 0 ? sides...(-1) : 1...sides
         
         for value in range {
             let outcome = ExpressionProbabilityMass.Outcome(value)

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -418,7 +418,7 @@ extension Die_Tests {
             typealias PM = ExpressionProbabilityMass
             
             let outcomePerValue = 1.0/PM.Probability(abs(sides))
-            let range = sides < 0 ? sides...1 : 1...sides
+            let range = sides < 0 ? sides...(-1) : 1...sides
             
             for value in range {
                 let outcome = ExpressionProbabilityMass.Outcome(value)
@@ -477,6 +477,18 @@ extension Die_Tests {
         let result = String(roll)
         
         expect(result) == expected
+    }
+    
+}
+
+//MARK: - ProbabilityMass for negative sided die
+extension Die_Tests {
+    
+    func test_die_negativeSidedProbabilityMass() {
+        let die = d(-2)
+        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution([-2: 0.5, -1: 0.5]))
+        
+        expect(die.probabilityMass) == expectedProbabilityMass
     }
     
 }


### PR DESCRIPTION
The range for a negative sided die was going up to 1 instead of stopping at -1. Fixing that.

If there's thoughts for more/better testing ideas for this let me know.
