### PR TITLE
Make `CustomStringConvertible` tests more resilient

### DIFF
--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -84,7 +84,7 @@ extension AdditionExpressionResult_Tests {
 // MARK: - CustomDebugStringConvertible
 extension AdditionExpressionResult_Tests {
     
-    func test_CustomDebuStringConvertible() {
+    func test_CustomDebugStringConvertible() {
         let expression = d(10) + 5
         let evaluation = expression.evaluate()
         let expected = "\(String(reflecting: Die.Roll(die: d(10), value: evaluation.leftAddendResult.value))) + \(String(reflecting: c(5)))"

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -87,7 +87,7 @@ extension AdditionExpressionResult_Tests {
     func test_CustomDebuStringConvertible() {
         let expression = d(10) + 5
         let evaluation = expression.evaluate()
-        let expected = "Die(10).Roll(\(evaluation.leftAddendResult.value)) + Constant(5)"
+        let expected = "\(String(reflecting: Die.Roll(die: d(10), value: evaluation.leftAddendResult.value))) + \(String(reflecting: c(5)))"
         
         let result = String(reflecting: evaluation)
         
@@ -102,7 +102,7 @@ extension AdditionExpressionResult_Tests {
     func test_CustomStringConvertible() {
         let expression = d(10) + 5
         let evaluation = expression.evaluate()
-        let expected = "\(evaluation.leftAddendResult.value)|10 + 5"
+        let expected = "\(Die.Roll(die: d(10), value: evaluation.leftAddendResult.value)) + \(c(5))"
         
         let result = String(evaluation)
         

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -145,7 +145,7 @@ extension AdditionExpression_Tests {
     
     func test_CustomDebugStringConvertible() {
         let expression = d(8) + 2
-        let expected = "Die(8) + Constant(2)"
+        let expected = "\(String(reflecting: d(8))) + \(String(reflecting: c(2)))"
         
         let result = String(reflecting: expression)
         
@@ -159,7 +159,7 @@ extension AdditionExpression_Tests {
     
     func test_CustomStringConvertible() {
         let expression = d(20) + d(4)
-        let expected = "d20 + d4"
+        let expected = "\(d(20)) + \(d(4))"
         
         let result = String(expression)
         

--- a/DiceKitTests/Die.Roll_Tests.swift
+++ b/DiceKitTests/Die.Roll_Tests.swift
@@ -95,3 +95,34 @@ extension Die_Roll_Tests {
     }
     
 }
+
+// MARK: - CustomDebugStringConvertible
+extension Die_Roll_Tests {
+
+    func test_customDebugStringConvertible() {
+        let die = d(4)
+        let roll = die.roll()
+        let expectedResult = "\(String(reflecting: d(4))).Roll(\(roll.value))"
+
+        let result = String(reflecting: roll)
+
+        expect(result) == expectedResult
+    }
+
+}
+
+//MARK: - CustomString Convertible
+extension Die_Roll_Tests {
+
+    func test_customStringConvertible() {
+        let die = d(6)
+        let roll = die.roll()
+        let val = roll.value
+        let expected = "\(val)|6"
+
+        let result = String(roll)
+
+        expect(result) == expected
+    }
+
+}

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -444,16 +444,6 @@ extension Die_Tests {
         expect(result) == expected
     }
     
-    func test_roll_customDebugStringConvertible() {
-        let die = d(4)
-        let roll = die.roll()
-        let expectedResult = "Die(4).Roll(\(roll.value))"
-        
-        let result = String(reflecting: roll)
-        
-        expect(result) == expectedResult
-    }
-    
 }
 
 //MARK: - CustomString Convertible
@@ -468,17 +458,6 @@ extension Die_Tests {
         expect(result) == expected
     }
     
-    func test_roll_customStringConvertible() {
-        let die = d(6)
-        let roll = die.roll()
-        let val = roll.value
-        let expected = "\(val)|6"
-        
-        let result = String(roll)
-        
-        expect(result) == expected
-    }
-    
 }
 
 //MARK: - ProbabilityMass for negative sided die
@@ -486,7 +465,7 @@ extension Die_Tests {
     
     func test_die_negativeSidedProbabilityMass() {
         let die = d(-2)
-        let expectedProbabilityMass = ProbabilityMass(FrequencyDistribution([-2: 0.5, -1: 0.5]))
+        let expectedProbabilityMass = ExpressionProbabilityMass(FrequencyDistribution([-2: 0.5, -1: 0.5]))
         
         expect(die.probabilityMass) == expectedProbabilityMass
     }

--- a/DiceKitTests/MaximizationExpression_Tests.swift
+++ b/DiceKitTests/MaximizationExpression_Tests.swift
@@ -23,9 +23,10 @@ class MaximizationExpression_Tests: XCTestCase {
 extension MinimizationExpression_Tests {
     
     func test_MaximizationExpression_CustomDebugStringConvertible() {
-        let expression = MaximizationExpression(d(8) + 2)
+        let innerExpression = d(8) + 2
+        let expression = MaximizationExpression(innerExpression)
         
-        let expected = "max(Die(8) + Constant(2))"
+        let expected = "max(\(String(reflecting: innerExpression)))"
         
         let result = String(reflecting: expression)
         
@@ -38,8 +39,9 @@ extension MinimizationExpression_Tests {
 extension MinimizationExpression_Tests {
     
     func test_MaximizationExpression_CustomStringConvertible() {
-        let expression = MaximizationExpression(d(20) + d(4))
-        let expected = "max(d20 + d4)"
+        let innerExpression = d(20) + d(4)
+        let expression = MaximizationExpression(innerExpression)
+        let expected = "max(\(innerExpression))"
         
         let result = String(expression)
         

--- a/DiceKitTests/MinimizationExpression_Tests.swift
+++ b/DiceKitTests/MinimizationExpression_Tests.swift
@@ -23,9 +23,10 @@ class MinimizationExpression_Tests: XCTestCase {
 extension MinimizationExpression_Tests {
     
     func test_MinimizationExpression_CustomDebugStringConvertible() {
-        let expression = MinimizationExpression(d(8) + 2)
+        let innerExpression = d(8) + 2
+        let expression = MinimizationExpression(innerExpression)
 
-        let expected = "min(Die(8) + Constant(2))"
+        let expected = "min(\(String(reflecting: innerExpression)))"
         
         let result = String(reflecting: expression)
         
@@ -38,8 +39,9 @@ extension MinimizationExpression_Tests {
 extension MinimizationExpression_Tests {
     
     func test_MinimizationExpression_CustomStringConvertible() {
-        let expression = MinimizationExpression(d(20) + d(4))
-        let expected = "min(d20 + d4)"
+        let innerExpression = d(20) + d(4)
+        let expression = MinimizationExpression(innerExpression)
+        let expected = "min(\(innerExpression))"
         
         let result = String(expression)
         

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -128,7 +128,7 @@ extension MultiplicationExpressionResult_Tests {
     func test_CustomDebugStringConvertible() {
         let expression = 2 * d(10)
         let evaluation = expression.evaluate()
-        let expected = "((Constant(2)) *> (\(String(reflecting: evaluation.multiplicandResults[0])) + \(String(reflecting: evaluation.multiplicandResults[1]))))"
+        let expected = "((\(String(reflecting: c(2)))) *> (\(String(reflecting: evaluation.multiplicandResults[0])) + \(String(reflecting: evaluation.multiplicandResults[1]))))"
         
         let result = String(reflecting: evaluation)
         
@@ -143,7 +143,7 @@ extension MultiplicationExpressionResult_Tests {
     func test_CustomStringConvertible() {
         let expression = 2 * d(10)
         let evaluation = expression.evaluate()
-        let expected = "((2) *> (\(evaluation.multiplicandResults[0]) + \(evaluation.multiplicandResults[1])))"
+        let expected = "((\(c(2))) *> (\(evaluation.multiplicandResults[0]) + \(evaluation.multiplicandResults[1])))"
         
         let result = String(evaluation)
         

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -150,7 +150,7 @@ extension MultiplicationExpression_Tests {
     
     func test_CustomDebugStringConvertible() {
         let expression = 2 * d(10)
-        let expected = "(Constant(2) * Die(10))"
+        let expected = "(\(String(reflecting: c(2))) * \(String(reflecting: d(10))))"
         
         let result = String(reflecting: expression)
         
@@ -162,12 +162,30 @@ extension MultiplicationExpression_Tests {
 // MARK: - CustomStringConvertible
 extension MultiplicationExpression_Tests {
     
-    func test_CustomStringConvertible() {
+    func test_CustomStringConvertible_constantAndDie() {
         let expression = 2 * d(10)
-        let expected = "2d10"
+        let expected = "\(c(2))\(d(10))"
         
         let result = String(expression)
         
+        expect(result) == expected
+    }
+
+    func test_CustomStringConvertible_expressionAndDie() {
+        let expression = d(20) * d(8)
+        let expected = "(\(d(20)))\(d(8))"
+
+        let result = String(expression)
+
+        expect(result) == expected
+    }
+
+    func test_CustomStringConvertible_expressionAndExpression() {
+        let expression = c(12) * c(24)
+        let expected = "(\(c(12)) * \(c(24)))"
+
+        let result = String(expression)
+
         expect(result) == expected
     }
     

--- a/DiceKitTests/SubtractionExpressionResult_Tests.swift
+++ b/DiceKitTests/SubtractionExpressionResult_Tests.swift
@@ -100,7 +100,7 @@ extension SubtractionExpressionResult_Tests {
 // MARK: - CustomDebugStringConvertible
 extension SubtractionExpressionResult_Tests {
     
-    func test_CustomDebuStringConvertible() {
+    func test_CustomDebugStringConvertible() {
         let expression = d(10) - 5
         let evaluation = expression.evaluate()
         let expected = "\(String(reflecting: Die.Roll(die: d(10), value: evaluation.minuendResult.value))) - \(String(reflecting: c(5)))"

--- a/DiceKitTests/SubtractionExpressionResult_Tests.swift
+++ b/DiceKitTests/SubtractionExpressionResult_Tests.swift
@@ -103,7 +103,7 @@ extension SubtractionExpressionResult_Tests {
     func test_CustomDebuStringConvertible() {
         let expression = d(10) - 5
         let evaluation = expression.evaluate()
-        let expected = "Die(10).Roll(\(evaluation.minuendResult.value)) - Constant(5)"
+        let expected = "\(String(reflecting: Die.Roll(die: d(10), value: evaluation.minuendResult.value))) - \(String(reflecting: c(5)))"
         
         let result = String(reflecting: evaluation)
         
@@ -118,7 +118,7 @@ extension SubtractionExpressionResult_Tests {
     func test_CustomStringConvertible() {
         let expression = d(10) - 5
         let evaluation = expression.evaluate()
-        let expected = "\(evaluation.minuendResult.value)|10 - 5"
+        let expected = "\(Die.Roll(die: d(10), value: evaluation.minuendResult.value)) - \(c(5))"
         
         let result = String(evaluation)
         

--- a/DiceKitTests/SubtractionExpression_Tests.swift
+++ b/DiceKitTests/SubtractionExpression_Tests.swift
@@ -148,7 +148,7 @@ extension SubtractionExpression_Tests {
     
     func test_CustomDebugStringConvertible() {
         let expression = d(8) - 2
-        let expected = "Die(8) - Constant(2)"
+        let expected = "\(String(reflecting: d(8))) - \(String(reflecting: c(2)))"
         
         let result = String(reflecting: expression)
         
@@ -162,7 +162,7 @@ extension SubtractionExpression_Tests {
     
     func test_CustomStringConvertible() {
         let expression = d(20) - d(4)
-        let expected = "d20 - d4"
+        let expected = "\(d(20)) - \(d(4))"
         
         let result = String(expression)
         


### PR DESCRIPTION
If we ever change the outcome type, then the strings won't content `Constant(2)` anymore. This change makes the unit tests focus on the exact thing they are trying to do. They don't care how individual things are printed, just how they compose those things.
