### PR TITLE
Remove `ForwardIndexType` requirement

### DIFF
--- a/DiceKit/FrequencyDistribution.swift
+++ b/DiceKit/FrequencyDistribution.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol FrequencyDistributionOutcomeType: InvertibleMultiplicativeType, ForwardIndexType, Hashable {
+public protocol FrequencyDistributionOutcomeType: InvertibleMultiplicativeType, Hashable {
     
     var multiplierEquivalent: Int { get }
     
@@ -247,27 +247,6 @@ extension FrequencyDistribution {
         }
     }
     
-    public func divide(y: FrequencyDistribution) -> FrequencyDistribution {
-        guard let initialK = orderedOutcomes.first, lastK = orderedOutcomes.last else {
-            return .additiveIdentity
-        }
-        guard let firstY = y.orderedOutcomes.first, lastY = y.orderedOutcomes.last, firstYFrequency = y[firstY] where firstYFrequency != 0.0 else {
-            fatalError("Invalid divide operation. The divisor expression must not be empty, and its first frequency must not be zero.")
-        }
-        
-        var xFrequencies: FrequenciesPerOutcome = [:]
-        for k in initialK...(lastK + lastY) {
-            var p: Frequency = 0.0
-            for (n, frequency) in xFrequencies {
-                p += frequency * (y[k - n] ?? 0)
-            }
-            xFrequencies[k - firstY] = ((frequenciesPerOutcome[k] ?? 0) - p) / firstYFrequency
-        }
-        
-        let delta = ProbabilityMassConfig.probabilityEqualityDelta
-        return FrequencyDistribution(xFrequencies).filterZeroFrequencies(delta)
-    }
-    
     /// This is a special case of `power(x: FrequencyDistribution)`,
     /// for when `x` is `FrequencyDistribution([x: 1])`.
     public func power(x: Outcome) -> FrequencyDistribution {
@@ -295,4 +274,30 @@ extension FrequencyDistribution {
         }
     }
     
+}
+
+// TODO: Remove the need for ForwardIndexType
+extension FrequencyDistribution where OutcomeType: ForwardIndexType {
+
+    public func divide(y: FrequencyDistribution) -> FrequencyDistribution {
+        guard let initialK = orderedOutcomes.first, lastK = orderedOutcomes.last else {
+            return .additiveIdentity
+        }
+        guard let firstY = y.orderedOutcomes.first, lastY = y.orderedOutcomes.last, firstYFrequency = y[firstY] where firstYFrequency != 0.0 else {
+            fatalError("Invalid divide operation. The divisor expression must not be empty, and its first frequency must not be zero.")
+        }
+
+        var xFrequencies: FrequenciesPerOutcome = [:]
+        for k in initialK...(lastK + lastY) {
+            var p: Frequency = 0.0
+            for (n, frequency) in xFrequencies {
+                p += frequency * (y[k - n] ?? 0)
+            }
+            xFrequencies[k - firstY] = ((frequenciesPerOutcome[k] ?? 0) - p) / firstYFrequency
+        }
+
+        let delta = ProbabilityMassConfig.probabilityEqualityDelta
+        return FrequencyDistribution(xFrequencies).filterZeroFrequencies(delta)
+    }
+
 }

--- a/DiceKit/ProbabilityMass.swift
+++ b/DiceKit/ProbabilityMass.swift
@@ -123,12 +123,6 @@ extension ProbabilityMass {
         return ProbabilityMass(freqDist, normalize: true)
     }
     
-    public func not(x: ProbabilityMass) -> ProbabilityMass {
-        let freqDist = frequencyDistribution.divide(x.frequencyDistribution)
-        
-        return ProbabilityMass(freqDist, normalize: true)
-    }
-    
     public func product(x: ProbabilityMass) -> ProbabilityMass {
         let freqDist = frequencyDistribution.power(x.frequencyDistribution)
         
@@ -141,6 +135,16 @@ extension ProbabilityMass {
     
     public func maximumOutcome() -> Outcome? {
         return frequencyDistribution.maximumOutcome()
+    }
+    
+}
+
+extension ProbabilityMass where OutcomeType: ForwardIndexType {
+
+    public func not(x: ProbabilityMass) -> ProbabilityMass {
+        let freqDist = frequencyDistribution.divide(x.frequencyDistribution)
+
+        return ProbabilityMass(freqDist, normalize: true)
     }
     
 }
@@ -171,7 +175,7 @@ infix operator !&& {
     precedence 140
 }
 
-public func !&& <V>(lhs: ProbabilityMass<V>, rhs: ProbabilityMass<V>) -> ProbabilityMass<V> {
+public func !&& <V: ForwardIndexType>(lhs: ProbabilityMass<V>, rhs: ProbabilityMass<V>) -> ProbabilityMass<V> {
     return lhs.not(rhs)
 }
 


### PR DESCRIPTION
... from `FrequencyDistributionOutcomeType`.

The methods that were dependent on it were set in special constraints. We need to remove the need for `ForwardIndexType` completely eventually, so we can use the methods again everywhere.
