### PR TITLE
Typealias `ExpressionResultValue`

### DIFF
--- a/DiceKit/AdditionExpression.swift
+++ b/DiceKit/AdditionExpression.swift
@@ -85,10 +85,10 @@ public func + <L: protocol<ExpressionType, Equatable>, R: protocol<ExpressionTyp
     return AdditionExpression(lhs, rhs)
 }
 
-public func + <R: protocol<ExpressionType, Equatable>>(lhs: Int, rhs: R) -> AdditionExpression<Constant, R> {
+public func + <R: protocol<ExpressionType, Equatable>>(lhs: ExpressionResultValue, rhs: R) -> AdditionExpression<Constant, R> {
     return AdditionExpression(Constant(lhs), rhs)
 }
 
-public func + <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: Int) -> AdditionExpression<L, Constant> {
+public func + <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: ExpressionResultValue) -> AdditionExpression<L, Constant> {
     return AdditionExpression(lhs, Constant(rhs))
 }

--- a/DiceKit/AdditionExpressionResult.swift
+++ b/DiceKit/AdditionExpressionResult.swift
@@ -50,8 +50,8 @@ public func == <L, R>(lhs: AdditionExpressionResult<L,R>, rhs: AdditionExpressio
 
 extension AdditionExpressionResult: ExpressionResultType {
     
-    public var value: Int {
-        return leftAddendResult.value + rightAddendResult.value
+    public var resultValue: ExpressionResultValue {
+        return leftAddendResult.resultValue + rightAddendResult.resultValue
     }
     
 }

--- a/DiceKit/Constant.swift
+++ b/DiceKit/Constant.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public struct Constant: Equatable {
     
-    public let value: Int
+    public let value: ExpressionResultValue
     
-    public init(_ value: Int) {
+    public init(_ value: ExpressionResultValue) {
         self.value = value
     }
     
@@ -20,7 +20,7 @@ public struct Constant: Equatable {
 
 // MARK: - Convenience Init
 
-public func c(value: Int) -> Constant {
+public func c(value: ExpressionResultValue) -> Constant {
     return Constant(value)
 }
 
@@ -57,7 +57,7 @@ extension Constant: IntegerLiteralConvertible {
     public typealias IntegerLiteralType = Int
     
     public init(integerLiteral value: IntegerLiteralType) {
-        self.value = value
+        self.value = ExpressionResultValue(integerLiteral: value)
     }
     
 }
@@ -73,7 +73,7 @@ extension Constant: ExpressionType {
     }
     
     public var probabilityMass: ExpressionProbabilityMass {
-        let probMassValue = ExpressionProbabilityMass.Outcome(value)
+        let probMassValue = value
         return ProbabilityMass(probMassValue)
     }
     
@@ -82,5 +82,9 @@ extension Constant: ExpressionType {
 // MARK: - ExpressionResultType
 
 extension Constant: ExpressionResultType {
-     // Already conforms because of `value`
+
+    public var resultValue: ExpressionResultValue {
+        return value
+    }
+
 }

--- a/DiceKit/Die.Roll.swift
+++ b/DiceKit/Die.Roll.swift
@@ -27,7 +27,10 @@ extension Die {
 // MARK: - ExpressionResultType
 
 extension Die.Roll: ExpressionResultType {
-    // Already conforms because of `value`
+
+    public var resultValue: ExpressionResultValue {
+        return ExpressionResultValue(integerLiteral: value)
+    }
 }
 
 // MARK: - CustomStringConvertible

--- a/DiceKit/Die.swift
+++ b/DiceKit/Die.swift
@@ -37,8 +37,8 @@ public struct Die: Equatable {
 
 // MARK: - Convenience Initialization Functions
 
-public func d(sides: Int) -> Die {
-    return Die(sides: sides)
+public func d(sides: ExpressionResultValue) -> Die {
+    return Die(sides: sides.multiplierEquivalent)
 }
 
 public func d() -> Die {
@@ -119,7 +119,7 @@ extension Die: ExpressionType {
         let range = sides < 0 ? sides...(-1) : 1...sides
         
         for value in range {
-            let outcome = ExpressionProbabilityMass.Outcome(value)
+            let outcome = ExpressionProbabilityMass.Outcome(integerLiteral: value)
             frequenciesPerOutcome[outcome] = frequencyPerOutcome
         }
         

--- a/DiceKit/ExpressionResultType.swift
+++ b/DiceKit/ExpressionResultType.swift
@@ -10,6 +10,6 @@ import Foundation
 
 public protocol ExpressionResultType {
     
-    var value: Int { get }
+    var resultValue: ExpressionResultValue { get }
     
 }

--- a/DiceKit/MaximizationExpressionResult.swift
+++ b/DiceKit/MaximizationExpressionResult.swift
@@ -10,10 +10,10 @@ import Foundation
 
 public struct MaximizationExpressionResult<MaximizationExpressionResult: protocol<ExpressionResultType, Equatable>>: Equatable {
     
-    public let maximizationExpressionResult: Int
+    public let resultValue: ExpressionResultValue
     
-    public init(_ maximizationExpressionResult: Int) {
-        self.maximizationExpressionResult = maximizationExpressionResult
+    public init(_ resultValue: ExpressionResultValue) {
+        self.resultValue = resultValue
     }
     
 }
@@ -23,7 +23,7 @@ public struct MaximizationExpressionResult<MaximizationExpressionResult: protoco
 extension MaximizationExpressionResult: CustomStringConvertible {
     
     public var description: String {
-        return "\(maximizationExpressionResult)"
+        return "\(resultValue)"
     }
     
 }
@@ -33,7 +33,7 @@ extension MaximizationExpressionResult: CustomStringConvertible {
 extension MaximizationExpressionResult: CustomDebugStringConvertible {
     
     public var debugDescription: String {
-        return "\(String(reflecting: maximizationExpressionResult))"
+        return "\(String(reflecting: resultValue))"
     }
     
 }
@@ -41,15 +41,13 @@ extension MaximizationExpressionResult: CustomDebugStringConvertible {
 // MARK: - Equatable
 
 public func == <L>(lhs: MaximizationExpressionResult<L>, rhs: MaximizationExpressionResult<L>) -> Bool {
-    return lhs.value == rhs.value
+    return lhs.resultValue == rhs.resultValue
 }
 
 // MARK: - ExpressionResultType
 
 extension MaximizationExpressionResult: ExpressionResultType {
     
-    public var value: Int {
-        return maximizationExpressionResult
-    }
+    // Already conforms because of `resultValue`
     
 }

--- a/DiceKit/MinimizationExpressionResult.swift
+++ b/DiceKit/MinimizationExpressionResult.swift
@@ -10,10 +10,10 @@ import Foundation
 
 public struct MinimizationExpressionResult<MinimizationExpressionResult: protocol<ExpressionResultType, Equatable>>: Equatable {
     
-    public let minimizationExpressionResult: Int
+    public let resultValue: ExpressionResultValue
     
-    public init(_ minimizationExpressionResult: Int) {
-        self.minimizationExpressionResult = minimizationExpressionResult
+    public init(_ resultValue: ExpressionResultValue) {
+        self.resultValue = resultValue
     }
     
 }
@@ -23,7 +23,7 @@ public struct MinimizationExpressionResult<MinimizationExpressionResult: protoco
 extension MinimizationExpressionResult: CustomStringConvertible {
     
     public var description: String {
-        return "\(minimizationExpressionResult)"
+        return "\(resultValue)"
     }
     
 }
@@ -33,7 +33,7 @@ extension MinimizationExpressionResult: CustomStringConvertible {
 extension MinimizationExpressionResult: CustomDebugStringConvertible {
     
     public var debugDescription: String {
-        return "\(String(reflecting: minimizationExpressionResult))"
+        return "\(String(reflecting: resultValue))"
     }
     
 }
@@ -41,15 +41,13 @@ extension MinimizationExpressionResult: CustomDebugStringConvertible {
 // MARK: - Equatable
 
 public func == <L>(lhs: MinimizationExpressionResult<L>, rhs: MinimizationExpressionResult<L>) -> Bool {
-    return lhs.value == rhs.value
+    return lhs.resultValue == rhs.resultValue
 }
 
 // MARK: - ExpressionResultType
 
 extension MinimizationExpressionResult: ExpressionResultType {
     
-    public var value: Int {
-        return minimizationExpressionResult
-    }
+    // Already conforms because of `resultValue`
     
 }

--- a/DiceKit/MultiplicationExpression.swift
+++ b/DiceKit/MultiplicationExpression.swift
@@ -28,10 +28,10 @@ extension MultiplicationExpression: ExpressionType {
     
     public func evaluate() -> Result {
         let muliplierResult = multiplier.evaluate()
-        let muliplierValue = muliplierResult.value
+        let muliplierValue = muliplierResult.resultValue
         
         // Negation is handled in the result
-        let multiplicandResultCount = abs(muliplierValue)
+        let multiplicandResultCount = abs(muliplierValue.multiplierEquivalent)
         let multiplicandResult = (0..<multiplicandResultCount).map { _ in self.multiplicand.evaluate() }
         
         return Result(multiplierResult: muliplierResult, multiplicandResults: multiplicandResult)
@@ -81,10 +81,10 @@ public func * <L: protocol<ExpressionType, Equatable>, R: protocol<ExpressionTyp
     return MultiplicationExpression(lhs, rhs)
 }
 
-public func * <R: protocol<ExpressionType, Equatable>>(lhs: Int, rhs: R)-> MultiplicationExpression<Constant, R> {
+public func * <R: protocol<ExpressionType, Equatable>>(lhs: ExpressionResultValue, rhs: R)-> MultiplicationExpression<Constant, R> {
     return MultiplicationExpression(Constant(lhs), rhs)
 }
 
-public func * <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: Int)-> MultiplicationExpression<L, Constant> {
+public func * <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: ExpressionResultValue)-> MultiplicationExpression<L, Constant> {
     return MultiplicationExpression(lhs, Constant(rhs))
 }

--- a/DiceKit/MultiplicationExpressionResult.swift
+++ b/DiceKit/MultiplicationExpressionResult.swift
@@ -15,11 +15,11 @@ public struct MultiplicationExpressionResult<MultiplierResult: protocol<Expressi
     public let negateMultiplicandResults: Bool
     
     public init(multiplierResult: MultiplierResult, multiplicandResults: [MultiplicandResult]) {
-        assert(abs(multiplierResult.value) == multiplicandResults.count)
+        assert(abs(multiplierResult.resultValue.multiplierEquivalent) == multiplicandResults.count)
         
         self.multiplierResult = multiplierResult
         self.multiplicandResults = multiplicandResults
-        self.negateMultiplicandResults = multiplierResult.value < 0
+        self.negateMultiplicandResults = multiplierResult.resultValue < 0
     }
     
 }
@@ -61,8 +61,8 @@ public func == <M, R>(lhs: MultiplicationExpressionResult<M,R>, rhs: Multiplicat
 
 extension MultiplicationExpressionResult: ExpressionResultType {
     
-    public var value: Int {
-        let values = multiplicandResults.map { $0.value }
+    public var resultValue: ExpressionResultValue {
+        let values = multiplicandResults.map { $0.resultValue }
         
         if negateMultiplicandResults {
             return values.reduce(0, combine: -)

--- a/DiceKit/NegationExpressionResult.swift
+++ b/DiceKit/NegationExpressionResult.swift
@@ -48,8 +48,8 @@ public func == <B>(lhs: NegationExpressionResult<B>, rhs: NegationExpressionResu
 
 extension NegationExpressionResult: ExpressionResultType {
     
-    public var value: Int {
-        return -base.value
+    public var resultValue: ExpressionResultValue {
+        return -base.resultValue
     }
     
 }

--- a/DiceKit/ProbabilisticExpressionType.swift
+++ b/DiceKit/ProbabilisticExpressionType.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public typealias ExpressionProbabilityMass = ProbabilityMass<Int>
+public typealias ExpressionResultValue = ExpressionProbabilityMass.Outcome
 
 public protocol ProbabilisticExpressionType {
     

--- a/DiceKit/SubtractionExpression.swift
+++ b/DiceKit/SubtractionExpression.swift
@@ -71,10 +71,10 @@ public func - <L: protocol<ExpressionType, Equatable>, R: protocol<ExpressionTyp
     return SubtractionExpression(lhs, rhs)
 }
 
-public func - <R: protocol<ExpressionType, Equatable>>(lhs: Int, rhs: R) -> SubtractionExpression<Constant, R> {
+public func - <R: protocol<ExpressionType, Equatable>>(lhs: ExpressionResultValue, rhs: R) -> SubtractionExpression<Constant, R> {
     return SubtractionExpression(Constant(lhs), rhs)
 }
 
-public func - <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: Int) -> SubtractionExpression<L, Constant> {
+public func - <L: protocol<ExpressionType, Equatable>>(lhs: L, rhs: ExpressionResultValue) -> SubtractionExpression<L, Constant> {
     return SubtractionExpression(lhs, Constant(rhs))
 }

--- a/DiceKit/SubtractionExpressionResult.swift
+++ b/DiceKit/SubtractionExpressionResult.swift
@@ -50,8 +50,8 @@ public func == <L, R>(lhs: SubtractionExpressionResult<L,R>, rhs: SubtractionExp
 
 extension SubtractionExpressionResult: ExpressionResultType {
     
-    public var value: Int {
-        return minuendResult.value - subtrahendResult.value
+    public var resultValue: ExpressionResultValue {
+        return minuendResult.resultValue - subtrahendResult.resultValue
     }
     
 }

--- a/DiceKitTests/AdditionExpressionResult_Tests.swift
+++ b/DiceKitTests/AdditionExpressionResult_Tests.swift
@@ -66,14 +66,14 @@ extension AdditionExpressionResult_Tests {
         property("add the addends") <- forAll {
             (a: Int16, b: Int16) in
             
-            let a = Int(a)
-            let b = Int(b)
+            let a = ExpressionResultValue(integerLiteral: Int(a))
+            let b = ExpressionResultValue(integerLiteral: Int(b))
             
             let expectedValue = a + b
             
             let result = AdditionExpressionResult(c(a), c(b))
             
-            let value = result.value
+            let value = result.resultValue
             
             return value == expectedValue
         }

--- a/DiceKitTests/AdditionExpression_Tests.swift
+++ b/DiceKitTests/AdditionExpression_Tests.swift
@@ -108,7 +108,7 @@ extension AdditionExpression_Tests {
     
     func test_operator_shouldWorkWithIntAndExpression() {
         property("Int + Expression and Expression + Int returns correct AdditionExpression") <- forAll {
-            (a: Int, b: Int) in
+            (a: ExpressionResultValue, b: ExpressionResultValue) in
             
             let die = d(b)
             let expectedExpression1 = AdditionExpression(c(a), die)
@@ -126,7 +126,7 @@ extension AdditionExpression_Tests {
     
     func test_operator_shouldWorkWithExpressionAndExpression() {
         property("Expression + Expression returns correct AdditionExpresson") <- forAll {
-            (a: Int, b: Int) in
+            (a: ExpressionResultValue, b: ExpressionResultValue) in
             
             let leftDie = d(a)
             let rightDie = d(b)

--- a/DiceKitTests/Arbitrary.swift
+++ b/DiceKitTests/Arbitrary.swift
@@ -21,7 +21,7 @@ public extension CollectionType where Index.Distance: protocol<Arbitrary, Intege
 extension Constant: Arbitrary {
     
     public static func create(x : Int) -> Constant {
-        return Constant(x)
+        return Constant(integerLiteral: x)
     }
     
     public static var arbitrary : Gen<Constant> {

--- a/DiceKitTests/Constant_Tests.swift
+++ b/DiceKitTests/Constant_Tests.swift
@@ -21,7 +21,7 @@ extension Constant_Tests {
     
     func test_init() {
         property("init") <- forAll {
-            (i: Int) in
+            (i: ExpressionResultValue) in
             
             let expectedValue = i
             
@@ -46,7 +46,7 @@ extension Constant_Tests {
     
     func test_shouldBeReflexive() {
         property("reflexive") <- forAll {
-            (i: Int) in
+            (i: ExpressionResultValue) in
             
             return EquatableTestUtilities.checkReflexive { Constant(i) }
         }
@@ -54,7 +54,7 @@ extension Constant_Tests {
     
     func test_shouldBeSymmetric() {
         property("symmetric") <- forAll {
-            (i: Int) in
+            (i: ExpressionResultValue) in
             
             return EquatableTestUtilities.checkSymmetric { Constant(i) }
         }
@@ -62,7 +62,7 @@ extension Constant_Tests {
     
     func test_shouldBeTransitive() {
         property("transitive") <- forAll {
-            (i: Int) in
+            (i: ExpressionResultValue) in
             
             return EquatableTestUtilities.checkTransitive { Constant(i) }
         }
@@ -70,7 +70,7 @@ extension Constant_Tests {
     
     func test_shouldBeAbleToNotEquate() {
         property("non-equal") <- forAll {
-            (a: Int, b: Int) in
+            (a: ExpressionResultValue, b: ExpressionResultValue) in
             
             return (a != b) ==> {
                 EquatableTestUtilities.checkNotEquate(

--- a/DiceKitTests/Die_Tests.swift
+++ b/DiceKitTests/Die_Tests.swift
@@ -104,10 +104,10 @@ extension Die_Tests {
     /// Tests the convenience function d(sides)
     func test_d_shouldReturnDie() {
         property("Returns correct die") <- forAll {
-            (a: Int) in
+            (a: ExpressionResultValue) in
             
             let dieFunction = d(a)
-            let dieInit = Die(sides: a)
+            let dieInit = Die(sides: a.multiplierEquivalent)
             
             return dieFunction == dieInit
         }
@@ -421,7 +421,7 @@ extension Die_Tests {
             let range = sides < 0 ? sides...(-1) : 1...sides
             
             for value in range {
-                let outcome = ExpressionProbabilityMass.Outcome(value)
+                let outcome = ExpressionProbabilityMass.Outcome(integerLiteral: value)
                 if probMass[outcome] != outcomePerValue {
                     return false
                 }

--- a/DiceKitTests/MaximizationExpressionResult_Tests.swift
+++ b/DiceKitTests/MaximizationExpressionResult_Tests.swift
@@ -26,28 +26,28 @@ extension MaximizationExpressionResult_Tests {
         let expression = MaximizationExpression(d(0))
         let result = expression.evaluate()
         
-        expect(result.value) == 0
+        expect(result.resultValue) == 0
     }
     
     func test_and_shouldReturnMaximumForSingleDie() {
         let expression = MaximizationExpression(d(8))
         let result = expression.evaluate()
         
-        expect(result.value) == 8
+        expect(result.resultValue) == 8
     }
     
     func test_and_shouldReturnMaximumForAddition() {
         let expression = MaximizationExpression(d(8) + 4)
         let result = expression.evaluate()
         
-        expect(result.value) == 12
+        expect(result.resultValue) == 12
     }
     
     func test_and_shouldReturnMaximumForMultiply() {
         let expression = MaximizationExpression(d(8) * 4)
         let result = expression.evaluate()
         
-        expect(result.value) == 32
+        expect(result.resultValue) == 32
     }
     
 }

--- a/DiceKitTests/MinimizationExpressionResult_Tests.swift
+++ b/DiceKitTests/MinimizationExpressionResult_Tests.swift
@@ -26,28 +26,28 @@ extension MinimizationExpressionResult_Tests {
         let expression = MinimizationExpression(d(0))
         let result = expression.evaluate()
         
-        expect(result.value) == 0
+        expect(result.resultValue) == 0
     }
     
     func test_and_shouldReturnMinimum() {
         let expression = MinimizationExpression(d(8))
         let result = expression.evaluate()
         
-        expect(result.value) == 1
+        expect(result.resultValue) == 1
     }
     
     func test_and_shouldReturnMinimumForAddition() {
         let expression = MinimizationExpression(d(8) + 4)
         let result = expression.evaluate()
         
-        expect(result.value) == 5
+        expect(result.resultValue) == 5
     }
     
     func test_and_shouldReturnMinimumForMultiply() {
         let expression = MinimizationExpression(d(8) * 4)
         let result = expression.evaluate()
         
-        expect(result.value) == 4
+        expect(result.resultValue) == 4
     }
     
 }

--- a/DiceKitTests/MockExpression.swift
+++ b/DiceKitTests/MockExpression.swift
@@ -30,9 +30,9 @@ class MockExpression: ExpressionType, Equatable {
 
 class MockExpressionResult: ExpressionResultType, Equatable {
     
-    var stubValue: Int = 0
+    var stubValue: ExpressionResultValue = 0
     
-    var value: Int {
+    var resultValue: ExpressionResultValue {
         return stubValue
     }
     

--- a/DiceKitTests/MultiplicationExpressionResult_Tests.swift
+++ b/DiceKitTests/MultiplicationExpressionResult_Tests.swift
@@ -21,9 +21,11 @@ class MultiplicationExpressionResult_Tests: XCTestCase {
 extension MultiplicationExpressionResult_Tests {
     
     func equatableFixture(a: UInt, _ b: UInt) -> (multiplierResult: Constant, multiplicandResults: [Constant]) {
-        let multiplierResult = Int(a % 101)
+        let multiplierResult = ExpressionResultValue(integerLiteral: Int(a % 101))
         let multiplicandRange = UInt32(b % 101)
-        let multiplicandResults = (0..<multiplierResult).map { _ in c(Int(arc4random_uniform(multiplicandRange))) }
+        let multiplicandResults = (0..<multiplierResult.multiplierEquivalent).map { _ in
+            c(ExpressionResultValue(integerLiteral: Int(arc4random_uniform(multiplicandRange))))
+        }
         
         return (c(multiplierResult), multiplicandResults)
     }
@@ -92,29 +94,29 @@ extension MultiplicationExpressionResult_Tests {
             
             let a = a.getArray
             
-            let multiplierResult = a.count
+            let multiplierResult = ExpressionResultValue(integerLiteral: a.count)
             let multiplicandResults = a
-            let expectedValue = multiplicandResults.reduce(0) { $0 + $1.value }
+            let expectedValue = multiplicandResults.reduce(0) { $0 + $1.resultValue }
             let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: multiplicandResults)
             
-            let value = result.value
+            let value = result.resultValue
             
             return value == expectedValue
         }
     }
     
     func test_value_shouldNegateTheMultiplicandResultsForNegativeMultiplier() {
-        property("value with positive multiplier") <- forAll {
+        property("value with negative multiplier") <- forAll {
             (a: ArrayOf<Constant>) in
             
             let a = a.getArray
         
-            let multiplierResult = -a.count
+            let multiplierResult = ExpressionResultValue(integerLiteral: -a.count)
             let multiplicandResults = a
-            let expectedValue = multiplicandResults.reduce(0) { $0 - $1.value }
+            let expectedValue = multiplicandResults.reduce(0) { $0 - $1.resultValue }
             let result = MultiplicationExpressionResult(multiplierResult: c(multiplierResult), multiplicandResults: multiplicandResults)
             
-            let value = result.value
+            let value = result.resultValue
             
             return value == expectedValue
         }

--- a/DiceKitTests/MultiplicationExpression_Tests.swift
+++ b/DiceKitTests/MultiplicationExpression_Tests.swift
@@ -82,7 +82,7 @@ extension MultiplicationExpression_Tests {
         
             let multiplicandResults = a.getArray
             let expectedMultiplicandResults = multiplicandResults
-            let leftExpression = c(expectedMultiplicandResults.count)
+            let leftExpression = c(ExpressionResultValue(integerLiteral: expectedMultiplicandResults.count))
             let expectedMultiplierResult = leftExpression
             let mockRightExpression = MockExpression()
             mockRightExpression.stubResulter = { multiplicandResults[mockRightExpression.evaluateCalled] }
@@ -116,8 +116,8 @@ extension MultiplicationExpression_Tests {
 extension MultiplicationExpression_Tests {
     
     func test_operator_shouldWorkWithIntAndExpression() {
-        property("Int * Expression and Expression * Int returns correct MultiplicationExpression") <- forAll {
-            (a: Int, die: Die) in
+        property("ExpressionResultValue * Expression and Expression * ExpressionResultValue returns correct MultiplicationExpression") <- forAll {
+            (a: ExpressionResultValue, die: Die) in
             
             let expectedExpression1 = MultiplicationExpression(c(a), die)
             let expectedExpression2 = MultiplicationExpression(die, c(a))

--- a/DiceKitTests/NegationExpressionResult_Tests.swift
+++ b/DiceKitTests/NegationExpressionResult_Tests.swift
@@ -66,10 +66,10 @@ extension NegationExpressionResult_Tests {
         property("negate the base result") <- forAll {
             (a: Constant) in
             
-            let expectedValue = -a.value
+            let expectedValue = -a.resultValue
             let result = NegationExpressionResult(a)
             
-            let value = result.value
+            let value = result.resultValue
             
             return value == expectedValue
         }

--- a/DiceKitTests/SubtractionExpressionResult_Tests.swift
+++ b/DiceKitTests/SubtractionExpressionResult_Tests.swift
@@ -66,7 +66,7 @@ extension SubtractionExpressionResult_Tests {
                 let y = SubtractionExpression(b, a).evaluate()
                 
                 let testNoncommutative = x != y
-                let testAnticommutative = x.value == -y.value
+                let testAnticommutative = x.resultValue == -y.resultValue
                 
                 return testNoncommutative && testAnticommutative
             }
@@ -82,14 +82,14 @@ extension SubtractionExpressionResult_Tests {
         property("Subtract subtrahend from minuend") <- forAll {
             (a: Int16, b: Int16) in
             
-            let minuend = Int(a)
-            let subtrahend = Int(b)
+            let minuend = ExpressionResultValue(integerLiteral: Int(a))
+            let subtrahend = ExpressionResultValue(integerLiteral: Int(b))
             
             let expectedValue = minuend - subtrahend
             
             let result = SubtractionExpressionResult(c(minuend), c(subtrahend))
             
-            let value = result.value
+            let value = result.resultValue
             
             return value == expectedValue
         }

--- a/DiceKitTests/SubtractionExpression_Tests.swift
+++ b/DiceKitTests/SubtractionExpression_Tests.swift
@@ -111,7 +111,7 @@ extension SubtractionExpression_Tests {
     
     func test_operator_shouldWorkWithIntAndExpression() {
         property("Int - Expression and Expression - Int returns correct SubtractionExpression") <- forAll {
-            (a: Int, b: Int) in
+            (a: ExpressionResultValue, b: ExpressionResultValue) in
             
             let die = d(b)
             let expectedExpression1 = SubtractionExpression(c(a), die)
@@ -129,7 +129,7 @@ extension SubtractionExpression_Tests {
     
     func test_operator_shouldWorkWithExpressionAndExpression() {
         property("Expression - Expression returns correct SubtractionExpresson") <- forAll {
-            (a: Int, b: Int) in
+            (a: ExpressionResultValue, b: ExpressionResultValue) in
             
             let leftDie = d(a)
             let rightDie = d(b)

--- a/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Exploring Expressions.xcplaygroundpage/Contents.swift
@@ -33,7 +33,7 @@ let twoD20result = twoD20.evaluate()
 let oneD2d3result = oneD2d3.evaluate()
 
 //: The result of the expression is always the sum of the rightmost term.
-let value = oneD2d3result.value
+let value = oneD2d3result.resultValue
 
 //: Try making more expressions in this playground. There is no limitation on what expression types you can put together to make a new expression. If your expression gets too complicated to easily tell its type, use the `dump()` function to investigate it in the console window.
 let whatIsThisExpression = d3 * (d(20) - 2)

--- a/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
+++ b/TomeOfKnowledge.playground/Pages/Expressions.xcplaygroundpage/Contents.swift
@@ -15,7 +15,7 @@ expression == expression2
 let result = expression.evaluate()
 
 //: Just like `Die.Roll` (because it's the `ExpressionResultType` for `Die`) the result is in the `value` property.
-let value = result.value
+let value = result.resultValue
 
 
 //: [Previous](@previous)


### PR DESCRIPTION
By having this be a type that can change later it makes it simpler to change to something dealing with Success checking.

Also renamed `ExpressionResultType.value` to `ExpressionResultType.resultValue`. This prevents name collisions with common`value` properties that types commonly have.
