### PR TITLE
Use associatedtype to declare associated types

### DIFF
--- a/DiceKit/ExpressionType.swift
+++ b/DiceKit/ExpressionType.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public protocol ExpressionType: ProbabilisticExpressionType {
     
-    typealias Result : ExpressionResultType, Equatable
+    associatedtype Result : ExpressionResultType, Equatable
     
     func evaluate() -> Result
     


### PR DESCRIPTION
In Swift 3, `typealias` can no longer be used to declare associated types. We must now use `associatedtype` moving forward. 
- Replace `typealias` with `associatedtype`.

@brentleyjones 
