### PR TITLE
Reduce CI warnings

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "brentleyjones/xcconfigs" ~> 0.1
-github "Quick/Nimble" ~> 3.2.0
+github "Quick/Nimble" "918ce7db"
 github "typelift/SwiftCheck" ~> 0.6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v3.2.0"
+github "Quick/Nimble" "918ce7db50c532cdaa6f0cc79c438f612d82b444"
 github "typelift/SwiftCheck" "v0.6.0"
 github "brentleyjones/xcconfigs" "v0.1"


### PR DESCRIPTION
The current version of Nimble produces too many warnings in the logs. Commits since their last release have fixed this, so I'm upping the submodule to a newer hash. 
- Update Nimble

@brentleyjones 
